### PR TITLE
fix overflow bugs in pyc module

### DIFF
--- a/libr/asm/arch/pyc/pyc_disasm.c
+++ b/libr/asm/arch/pyc/pyc_disasm.c
@@ -268,7 +268,8 @@ char *generic_array_obj_to_string (RList *l) {
     ut32 size = 256, used = 0;
     char *r = NULL, *buf = NULL;
 
-    buf = (char*)calloc (1024, 0);
+    // add good enough space
+    buf = (char*)calloc (size+10, 1);
     r_list_foreach (l, iter, e) {
         while ( !(strlen (e->data) < size) ) {
             size *= 2;

--- a/libr/bin/format/pyc/marshal.c
+++ b/libr/bin/format/pyc/marshal.c
@@ -234,7 +234,7 @@ static pyc_object *get_float_object (RBuffer *buffer) {
     ret = R_NEW0 (pyc_object);
     if (!ret) 
         return NULL;
-    ut8 *s = malloc (n);
+    ut8 *s = malloc (n + 1);
     if (!s) 
         return NULL;
     /* object contain string representation of the number */


### PR DESCRIPTION
I found two very subtle bugs in the pyc bin and asm module.The first one is a very obvious heap overflow (initial size is 0) and the second one is a single NULL byte overflow. 