### PR TITLE
Fix #225 - Python pyc fix for section detection 

### DIFF
--- a/libr/bin/format/pyc/marshal.c
+++ b/libr/bin/format/pyc/marshal.c
@@ -956,7 +956,8 @@ static bool extract_sections (pyc_object *obj, RList *sections, RList *cobjs, ch
                 prefix ? "." : "", cobj->name->data);
     if (!prefix || !section)
         goto fail;
-    if (!strncpy ((char*)&section->name, prefix, R_BIN_SIZEOF_STRINGS))
+    section->name = strdup(prefix);
+    if (!section->name)
         goto fail;
     section->paddr = cobj->start_offset+1;
     section->vaddr = cobj->start_offset+1;

--- a/libr/bin/format/pyc/pyc.c
+++ b/libr/bin/format/pyc/pyc.c
@@ -7,7 +7,7 @@ bool pyc_get_sections(RList *sections, RList *cobjs, RBuffer *buf, ut32 magic) {
 	return get_sections_from_code_objects (buf, sections, cobjs);
 }
 
-bool pyc_is_object(ut32 b, pyc_marshal_type type) {
+bool pyc_is_object(ut8 b, pyc_marshal_type type) {
     bool ret = false;
 	if (b == type) {
         ret = true;
@@ -15,7 +15,7 @@ bool pyc_is_object(ut32 b, pyc_marshal_type type) {
     return ret;
 }
 
-bool pyc_is_code(ut32 b) {
+bool pyc_is_code(ut8 b) {
     if (pyc_is_object((b & ~FLAG_REF), TYPE_CODE_v1)) {
         return true;
     }

--- a/libr/bin/format/pyc/pyc.h
+++ b/libr/bin/format/pyc/pyc.h
@@ -12,7 +12,7 @@
 
 bool pyc_get_sections(RList *sections, RList* mem, RBuffer *buf, ut32 magic);
 ut64 pyc_get_entrypoint(ut32 magic);
-bool pyc_is_object(ut32 b, pyc_marshal_type type);
-bool pyc_is_code(ut32 b);
+bool pyc_is_object(ut8 b, pyc_marshal_type type);
+bool pyc_is_code(ut8 b);
 
 #endif

--- a/libr/bin/p/bin_pyc.c
+++ b/libr/bin/p/bin_pyc.c
@@ -24,7 +24,7 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf,  ut64 loadad
 }
 
 static ut64 get_entrypoint(RBuffer *buf) {
-    ut32 b;
+    ut8 b;
     for (int addr = 0x8; addr <= 0x10; addr += 0x4) {
         r_buf_read_at (buf, addr, &b, sizeof (b));
         if (pyc_is_code(b)) {
@@ -85,7 +85,7 @@ static RList *entries(RBinFile *arch) {
 	ut64 entrypoint = get_entrypoint (arch->buf);
 	addr->paddr = entrypoint;
 	addr->vaddr = entrypoint;
-	r_buf_seek (arch->buf, entrypoint, R_IO_SEEK_CUR);
+	r_buf_seek (arch->buf, entrypoint, R_IO_SEEK_SET);
 	r_list_append (entries, addr);
 	return entries;
 }


### PR DESCRIPTION


<!--- Filling this template is mandatory -->

**Detailed description**
- Correct pointer offset after finding entry point
- Define the right size for Python object type
- Prevent memory corruption problem when naming section
<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->
```
$> cat fhello.py
def hello():
    print("hello world!\n")

hello()
$> python2.7 -m py_compile fhello.py
$> rabin2 -S fhello.pyc 
[Sections]

nth paddr       size vaddr       vsize perm name
――――――――――――――――――――――――――――――――――――――――――――――――
0   0x0000001e  0x14 0x0000001e   0x14 ---- module
1   0x0000004d   0x9 0x0000004d    0x9 ---- module_.hello
```

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #225 
...
