### PR TITLE
Fix and refactor pcap r_bin plugin

### DIFF
--- a/libr/bin/format/pcap/pcap.c
+++ b/libr/bin/format/pcap/pcap.c
@@ -1,151 +1,468 @@
+#include <r_bin.h>
+
 #include "pcap.h"
 
-void read_pcap_file_hdr(pcap_file_hdr_t *hdr, const ut8 *buf, int swap_endian) {
-	memcpy (hdr, buf, sizeof (pcap_file_hdr_t));
-	if (swap_endian) {
-		hdr->magic = r_swap_ut32 (hdr->magic);
-		hdr->version_major = r_swap_ut16 (hdr->version_major);
-		hdr->version_minor = r_swap_ut16 (hdr->version_minor);
-		hdr->this_zone = r_swap_st32 (hdr->this_zone);
-		hdr->ts_accuracy = r_swap_ut32 (hdr->ts_accuracy);
-		hdr->max_pkt_len = r_swap_ut32 (hdr->max_pkt_len);
-		hdr->network = r_swap_ut32 (hdr->network);
+void pcap_obj_free (pcap_obj_t *obj) {
+	if (obj) {
+		free (obj->header);
+		r_list_free (obj->recs);
+		r_buf_fini (obj->b);
+		free (obj);
 	}
 }
 
-void read_pcap_pktrec_hdr(pcap_pktrec_hdr_t *hdr, const ut8 *buf, int swap_endian) {
-	memcpy (hdr, buf, sizeof (pcap_pktrec_hdr_t));
-	if (swap_endian) {
-		hdr->ts_sec = r_swap_ut32 (hdr->ts_sec);
-		hdr->ts_usec = r_swap_ut32 (hdr->ts_usec);
-		hdr->cap_len = r_swap_ut32 (hdr->cap_len);
-		hdr->orig_len = r_swap_ut32 (hdr->orig_len);
+static bool pcap_obj_init_hdr(pcap_obj_t *obj) {
+	pcap_hdr_t *hdr = R_NEW0 (pcap_hdr_t);
+	if (!hdr) {
+		return false;
+	}
+	hdr->magic = r_buf_read_ble32_at (obj->b, 0, obj->bigendian);
+	hdr->version_major = r_buf_read_ble16_at (obj->b, 4, obj->bigendian);
+	hdr->version_minor = r_buf_read_ble16_at (obj->b, 6, obj->bigendian);
+	hdr->this_zone = r_buf_read_ble32_at (obj->b, 8, obj->bigendian);
+	hdr->ts_accuracy = r_buf_read_ble32_at (obj->b, 12, obj->bigendian);
+	hdr->max_pkt_len = r_buf_read_ble32_at (obj->b, 16, obj->bigendian);
+	hdr->network = r_buf_read_ble32_at (obj->b, 20, obj->bigendian);
+	obj->header = hdr;
+	return true;
+}
+
+void pcaprec_free(pcaprec_t *rec) {
+	if (rec) {
+		free (rec->hdr);
+		free (rec->link.ether_hdr);
+		free (rec->net.ipv4_hdr);
+		free (rec->transport.tcp_hdr);
+		free (rec->data);
+		free (rec);
 	}
 }
 
-void read_pcap_pktrec_ether(pcap_pktrec_ether_t *hdr, const ut8 *buf, int swap_endian) {
-	memcpy (hdr, buf, sizeof (pcap_pktrec_ether_t));
-	if (swap_endian) {
-		hdr->type = r_swap_ut16 (hdr->type);
+static void parse_tcp (pcaprec_t *rec, ut8 *buf, ut32 size, bool bigendian) {
+	pcaprec_tcp_t *tcp = R_NEW0 (pcaprec_tcp_t);
+	if (!tcp) {
+		return;
+	}
+	tcp->src_port = r_read_at_be16 (buf, 0);
+	tcp->dst_port = r_read_at_be16 (buf, 2);
+	tcp->seq_num = r_read_at_be32 (buf, 4);
+	tcp->ack_num = r_read_at_be32 (buf, 8);
+	tcp->hdr_len = r_read_at_be8 (buf, 12);
+	tcp->flags = r_read_at_be16 (buf, 13);
+	tcp->win_sz = r_read_at_be16 (buf, 15);
+	tcp->chksum = r_read_at_be16 (buf, 17);
+	tcp->urgnt_ptr = r_read_at_be16 (buf, 19);
+	rec->transport.tcp_hdr = tcp;
+
+	// data offset at (((tcp->hdr_len >> 4) & 0x0F) * 4)
+	ut32 dataoff = ((tcp->hdr_len & 0xF0) >> 2);
+	rec->datasz = size - dataoff;
+	rec->data = malloc (rec->datasz);
+	if (!rec->data) {
+		free (tcp);
+		return;
+	}
+	memcpy (rec->data, buf + dataoff, rec->datasz);
+}
+
+static void parse_ipv4 (pcaprec_t *rec, ut8 *buf, bool bigendian) {
+	pcaprec_ipv4_t *ipv4 = R_NEW0 (pcaprec_ipv4_t);
+	if (!ipv4) {
+		return;
+	}
+	ipv4->ver_len = r_read_at_be8 (buf, 0);
+	ipv4->diff_serv = r_read_at_be8 (buf, 1);
+	ipv4->tot_len = r_read_at_be16 (buf, 2);
+	ipv4->id = r_read_at_be16 (buf, 4);
+	ipv4->flag_frag = r_read_at_be16 (buf, 6);
+	ipv4->ttl = r_read_at_be8 (buf, 8);
+	ipv4->protocol = r_read_at_be8 (buf, 9);
+	ipv4->chksum = r_read_at_be16 (buf, 10);
+	ipv4->src = r_read_at_be32 (buf, 12);
+	ipv4->dst = r_read_at_be32 (buf, 16);
+
+	switch (ipv4->protocol) {
+	case TRANSPORT_TCP:
+	{
+		ut32 tcpoff = ((ipv4->ver_len & 0x0F) * 4);
+		parse_tcp (rec, buf + tcpoff, ipv4->tot_len - tcpoff, bigendian);
+		break;
+	}
+	default:
+		break;
+	}
+	rec->net.ipv4_hdr = ipv4;
+}
+
+static void parse_ipv6 (pcaprec_t *rec, ut8 *buf, bool bigendian) {
+	pcaprec_ipv6_t *ipv6 = R_NEW0 (pcaprec_ipv6_t);
+	if (!ipv6) {
+		return;
+	}
+	memcpy (ipv6, buf, sizeof (pcaprec_ipv6_t));
+	ipv6->vc_flow = r_read_at_be32 (buf, 0);
+	ipv6->plen = r_read_at_be16 (buf, 4);
+	switch (ipv6->nxt) {
+	case TRANSPORT_TCP:
+		parse_tcp (rec, buf + sizeof (pcaprec_ipv6_t), ipv6->plen, bigendian);
+		break;
+	default:
+		break;
+	}
+	rec->net.ipv6_hdr = ipv6;
+}
+
+static void parse_ether (pcaprec_t *rec, ut8 *buf, bool bigendian) {
+	pcaprec_ether_t *ether = R_NEW0 (pcaprec_ether_t);
+	if (!ether) {
+		return;
+	}
+	// dst 6 bytes
+	// src 6 bytes
+	memcpy (ether, buf, 12);
+	ether->type = r_read_at_be16 (buf, 12);
+	switch (ether->type) {
+	case NET_IPV4:
+		parse_ipv4 (rec, buf + sizeof (pcaprec_ether_t), bigendian);
+		break;
+	case NET_IPV6:
+		parse_ipv6 (rec, buf + sizeof (pcaprec_ether_t), bigendian);
+		break;
+	}
+	rec->link.ether_hdr = ether;
+}
+
+static bool pcap_obj_init_recs (pcap_obj_t *obj) {
+	ut64 off = sizeof (pcap_hdr_t);
+	ut64 size = r_buf_size (obj->b);
+	if (size == 0 || size == UT64_MAX) {
+		return false;
+	}
+	RList *recs = r_list_newf ((RListFree)pcaprec_free);
+	if (!recs) {
+		return false;
+	}
+
+	while (off < size) {
+		pcaprec_hdr_t *rec_hdr = R_NEW0 (pcaprec_hdr_t);
+		if (!rec_hdr) {
+			goto error;
+		}
+		rec_hdr->ts_sec = r_buf_read_ble32_at (obj->b, off, obj->bigendian);
+		rec_hdr->ts_usec = r_buf_read_ble32_at (obj->b, off + 4, obj->bigendian);
+		rec_hdr->incl_len = r_buf_read_ble32_at (obj->b, off + 8, obj->bigendian);
+		rec_hdr->orig_len = r_buf_read_ble32_at (obj->b, off + 12, obj->bigendian);
+		if (off + sizeof (rec_hdr) + rec_hdr->incl_len > size) {
+			free (rec_hdr);
+			goto error;
+		}
+		off += 16;
+
+		pcaprec_t *rec = R_NEW0 (pcaprec_t);
+		if (!rec) {
+			free (rec_hdr);
+			goto error;
+		}
+		rec->paddr = off;
+		rec->hdr = rec_hdr;
+		ut8 *pktbuf = malloc (rec_hdr->incl_len);
+		if (!pktbuf) {
+			free (rec_hdr);
+			goto error;
+		}
+		if (r_buf_read_at (obj->b, off, pktbuf, rec_hdr->incl_len) < 0) {
+			free (rec->data);
+			free (rec_hdr);
+			goto error;
+		}
+
+		switch (obj->header->network) {
+		case LINK_ETHERNET:
+			parse_ether (rec, pktbuf, obj->bigendian);
+		default:
+			break;
+		}
+		free (pktbuf);
+		r_list_append (recs, rec);
+		off += rec_hdr->incl_len;
+	}
+	obj->recs = recs;
+	return true;
+error:
+	r_list_free (recs);
+	return false;
+}
+
+static bool pcap_obj_init (pcap_obj_t *obj) {
+	switch (r_buf_read_be32_at (obj->b, 0)) {
+	case PCAP_MAGIC_LE:
+		obj->bigendian = false;
+		obj->is_nsec = false;
+		break;
+	case PCAP_MAGIC_BE:
+		obj->bigendian = true;
+		obj->is_nsec = false;
+		break;
+	case PCAP_NSEC_MAGIC_LE:
+		obj->bigendian = false;
+		obj->is_nsec = true;
+		break;
+	case PCAP_NSEC_MAGIC_BE:
+		obj->bigendian = true;
+		obj->is_nsec = true;
+		break;
+	default:
+		return false;
+	}
+
+	if (!pcap_obj_init_hdr (obj)) {
+		return false;
+	}
+	if (!pcap_obj_init_recs (obj)) {
+		return false;
+	}
+	return true;
+}
+
+pcap_obj_t *pcap_obj_new_buf(RBuffer *buf) {
+	r_return_val_if_fail (buf, NULL);
+
+	pcap_obj_t *obj = R_NEW0 (pcap_obj_t);
+	if (!obj) {
+		return NULL;
+	}
+	obj->b = r_buf_ref (buf);
+
+	if (!pcap_obj_init (obj)) {
+		pcap_obj_free (obj);
+		return NULL;
+	}
+	return obj;
+}
+
+static void pcaprec_tcp_sym_add(RList *list, pcaprec_t* rec, ut64 paddr, ut32 size) {
+	RBinSymbol *ptr = R_NEW0 (RBinSymbol);
+	if (!ptr) {
+		return;
+	}
+	pcaprec_tcp_t *tcp = rec->transport.tcp_hdr;
+	ut32 datasz = size - ((tcp->hdr_len & 0xF0) >> 2);
+	ptr->name = r_str_newf ("0x%"PFMT64x": Transmission Control Protocol, Src Port: %d, Dst"
+		" port: %d, Len: %d", paddr, tcp->src_port, tcp->dst_port, datasz);
+	ptr->paddr = ptr->vaddr = paddr;
+	r_list_append (list, ptr);
+}
+
+static void pcaprec_ipv4_sym_add(RList *list, pcaprec_t* rec, ut64 paddr) {
+	RBinSymbol *ptr = R_NEW0 (RBinSymbol);
+	if (!ptr) {
+		return;
+	}
+	pcaprec_ipv4_t *ipv4 = rec->net.ipv4_hdr;
+	ptr->name = r_str_newf ("0x%"PFMT64x": IPV%d, Src: %d.%d.%d.%d, Dst: %d.%d.%d.%d",
+		paddr, (ipv4->ver_len >> 4) & 0x0F,
+	(ipv4->src >> 24) & 0xFF, (ipv4->src >> 16) & 0xFF,
+	(ipv4->src >> 8) & 0xFF, ipv4->src & 0xFF,
+	(ipv4->dst >> 24) & 0xFF, (ipv4->dst >> 16) & 0xFF,
+	(ipv4->dst >> 8) & 0xFF, ipv4->dst & 0xFF);
+	ptr->paddr = ptr->vaddr = paddr;
+	r_list_append (list, ptr);
+
+	switch (ipv4->protocol) {
+	case TRANSPORT_TCP:
+	{
+		ut32 tcpoff = ((ipv4->ver_len & 0x0F) * 4);
+		pcaprec_tcp_sym_add (list, rec, paddr + tcpoff, ipv4->tot_len - tcpoff);
+		break;
+	}
+	default:
+		break;
 	}
 }
 
-void read_pcap_pktrec_ipv4(pcap_pktrec_ipv4_t *hdr, const ut8 *buf, int swap_endian) {
-	memcpy (hdr, buf, sizeof (pcap_pktrec_ipv4_t));
-	hdr->tot_len = r_read_be16 (&hdr->tot_len);
-	hdr->src = r_read_be32 (&hdr->src);
-	hdr->dst = r_read_be32 (&hdr->dst);
-	hdr->id = r_read_be16 (&hdr->id);
-	hdr->flag_frag = r_read_be16 (&hdr->flag_frag);
-	hdr->chksum = r_read_be16 (&hdr->chksum);
-}
+static void pcaprec_ipv6_sym_add(RList *list, pcaprec_t* rec, ut64 paddr) {
+	RBinSymbol *ptr = R_NEW0 (RBinSymbol);
+	if (!ptr) {
+		return;
+	}
+	pcaprec_ipv6_t *ipv6 = rec->net.ipv6_hdr;
+	const char *src = ipv6_addr_string (ipv6->src);
+	const char *dst = ipv6_addr_string (ipv6->dst);
+	ptr->name = r_str_newf ("0x%"PFMT64x": IPV6, Src: %s, Dst: %s", paddr, src, dst);
+	ptr->paddr = ptr->vaddr = paddr;
+	r_list_append (list, ptr);
+	free ((char *)src);
+	free ((char *)dst);
 
-void read_pcap_pktrec_ipv6(pcap_pktrec_ipv6_t *hdr, const ut8 *buf, int swap_endian) {
-	memcpy (hdr, buf, sizeof (pcap_pktrec_ipv6_t));
-	if (swap_endian) {
-		hdr->plen = r_swap_ut16 (hdr->plen);
+	switch (ipv6->nxt) {
+	case TRANSPORT_TCP:
+		pcaprec_tcp_sym_add (list, rec, paddr + sizeof (pcaprec_ipv6_t), ipv6->plen);
+		break;
+	default:
+		break;
 	}
 }
 
-void read_pcap_pktrec_tcp(pcap_pktrec_tcp_t *hdr, const ut8 *buf, int swap_endian) {
-	memcpy (hdr, buf, sizeof (pcap_pktrec_tcp_t));
-	hdr->src_port = r_read_be16 (&hdr->src_port);
-	hdr->dst_port = r_read_be16 (&hdr->dst_port);
-	hdr->seq_num = r_read_be32 (&hdr->seq_num);
-	hdr->ack_num = r_read_be32 (&hdr->ack_num);
-	hdr->flags = r_read_be16 (&hdr->flags);
-	hdr->win_sz = r_read_be16 (&hdr->win_sz);
-	hdr->chksum = r_read_be16 (&hdr->chksum);
-	hdr->urgnt_ptr = r_read_be16 (&hdr->urgnt_ptr);
+void pcaprec_ether_sym_add(RList *list, pcaprec_t *rec, ut64 paddr) {
+	RBinSymbol *ptr = R_NEW0 (RBinSymbol);
+	if (!ptr) {
+		return;
+	}
+	pcaprec_ether_t *ether = rec->link.ether_hdr;
+	ptr->name = r_str_newf ("0x%"PFMT64x": Ethernet, Src: %02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x
+		":%02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x ", Dst: %02"PFMT32x
+		":%02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x,
+		paddr, ether->src[0], ether->src[1], ether->src[2], ether->src[3], ether->src[4], ether->src[5],
+		ether->dst[0], ether->dst[1], ether->dst[2], ether->dst[3], ether->dst[4], ether->dst[5]);
+	ptr->paddr = ptr->vaddr = paddr;
+	r_list_append (list, ptr);
+
+	switch (ether->type) {
+	case NET_IPV4:
+		pcaprec_ipv4_sym_add (list, rec, paddr + sizeof (pcaprec_ether_t));
+		break;
+	case NET_IPV6:
+		pcaprec_ipv6_sym_add (list, rec, paddr + sizeof (pcaprec_ether_t));
+		break;
+	default:
+		break;
+	}
 }
 
-const char* pcap_net_type(ut32 net) {
-	switch (net) {
-	case NOLINK:
+const char* pcap_network_string(ut32 network) {
+	switch (network) {
+	case LINK_NOLINK:
 		return "No link-layer encapsulation";
-	case ETHERNET:
+	case LINK_ETHERNET:
 		return "Ethernet";
-	case ETHERNET_3MB:
+	case LINK_ETHERNET_3MB:
 		return "3Mb Ethernet";
-	case AX_25:
+	case LINK_AX_25:
 		return "AX.25";
-	case PRONET:
+	case LINK_PRONET:
 		return "ProNET";
-	case CHAOS:
+	case LINK_CHAOS:
 		return "CHAOS";
-	case TOKEN_RING:
+	case LINK_TOKEN_RING:
 		return "Token Ring";
-	case ARCNET:
+	case LINK_ARCNET:
 		return "ARCNET";
-	case SLIP:
+	case LINK_SLIP:
 		return "SLIP";
-	case PPP:
+	case LINK_PPP:
 		return "PPP";
-	case FDDI:
+	case LINK_FDDI:
 		return "FDDI";
-	case RFC_1483_ATM_1:
-	case RFC_1483_ATM_2:
+	case LINK_RFC_1483_ATM_1:
+	case LINK_RFC_1483_ATM_2:
 		return "RFC 1483 ATM";
-	case RAW_IP_1:
-	case RAW_IP_2:
+	case LINK_RAW_IP_1:
+	case LINK_RAW_IP_2:
 		return "raw IP";
-	case BSDOS_SLIP_1:
-	case BSDOS_SLIP_2:
+	case LINK_BSDOS_SLIP_1:
+	case LINK_BSDOS_SLIP_2:
 		return "BSD/OS SLIP";
-	case BSDOS_PPP_1:
-	case BSDOS_PPP_2:
+	case LINK_BSDOS_PPP_1:
+	case LINK_BSDOS_PPP_2:
 		return "BSD/OS PPP";
-	case LINUX_ATM_CLASSICAL_IP:
+	case LINK_LINUX_ATM_CLASSICAL_IP:
 		return "Linux ATM Classical IP";
-	case PPP_CISCO_HDLC:
+	case LINK_PPP_CISCO_HDLC:
 		return "PPP or Cisco HDLC";
-	case PPP_OVER_ETHERNET:
+	case LINK_PPP_OVER_ETHERNET:
 		return "PPP-over-Ethernet";
-	case SYMANTEC_FIREWALL:
+	case LINK_SYMANTEC_FIREWALL:
 		return "Symantec Enterprise Firewall";
-	case BSDOS_CISCO_HDLC:
+	case LINK_BSDOS_CISCO_HDLC:
 		return "BSD/OS Cisco HDLC";
-	case _802_11:
+	case LINK_802_11:
 		return "802.11";
-	case LINUX_CLASSICAL_IP_ATM:
+	case LINK_LINUX_CLASSICAL_IP_ATM:
 		return "Linux Classical IP over ATM";
-	case FRAME_RELAY:
+	case LINK_FRAME_RELAY:
 		return "Frame Relay";
-	case OPENBSD_LOOPBACK:
+	case LINK_OPENBSD_LOOPBACK:
 		return "OpenBSD loopback";
-	case OPENBSD_IPSEC_ENC:
+	case LINK_OPENBSD_IPSEC_ENC:
 		return "OpenBSD IPsec encrypted";
-	case CISCO_HDLC:
+	case LINK_CISCO_HDLC:
 		return "Cisco HDLC";
-	case LINUX_COOKED:
+	case LINK_LINUX_COOKED:
 		return "Linux \"cooked\"";
-	case LOCALTALK:
+	case LINK_LOCALTALK:
 		return "LocalTalk";
-	case OPENBSD_PFLOG:
+	case LINK_OPENBSD_PFLOG:
 		return "OpenBSD PFLOG";
-	case _802_11_PRISM:
+	case LINK_802_11_PRISM:
 		return "802.11 with Prism header";
-	case RFC_2625_IP_FIBRE_CHANNEL:
+	case LINK_RFC_2625_IP_FIBRE_CHANNEL:
 		return "RFC 2625 over Fibre Channel";
-	case SUNATM:
+	case LINK_SUNATM:
 		return "SunATM";
-	case _802_11_RADIOTAP:
+	case LINK_802_11_RADIOTAP:
 		return "802.11 with radiotap header";
-	case LINUX_ARCNET:
+	case LINK_LINUX_ARCNET:
 		return "Linux ARCNET";
-	case APPLE_IP_IEEE_1394:
+	case LINK_APPLE_IP_IEEE_1394:
 		return "Apple IP over IEEE 1394";
-	case MTP2:
+	case LINK_MTP2:
 		return "MTP2";
-	case MTP3:
+	case LINK_MTP3:
 		return "MTP3";
-	case DOCSIS:
+	case LINK_DOCSIS:
 		return "DOCSIS";
-	case IRDA:
+	case LINK_IRDA:
 		return "IrDA";
-	case _802_11_AVS_HDR:
+	case LINK_802_11_AVS_HDR:
 		return "802.11 with AVS header";
 	default:
 		return "Unkown";
 	}
+}
+
+const char *ipv6_addr_string(ut8 *addr) {
+	size_t i;
+	size_t start = -1;
+	size_t tmp = -1;
+	size_t len = 0, maxlen = 0;
+
+	ut16 words[8] = { 0 };
+	for (i = 0; i < 8; i++) {
+		words[i] = r_read_at_be16 (addr, i * 2);
+	}
+
+	// find the longest sequence of zero field
+	for (i = 0; i < 8; i++) {
+		if (words[i] == 0) {
+			if (tmp == -1) {
+				tmp = i;
+				len = 1;
+			} else {
+				len++;
+			}
+			continue;
+		}
+
+		if (len > maxlen) {
+			maxlen = len;
+			start = tmp;
+		}
+		tmp = -1;
+	}
+
+	if (maxlen > 1) {
+		RStrBuf *addr = r_strbuf_new (NULL);
+		for (i = 0; i < 8; i++) {
+			if (i == start) {
+				r_strbuf_append (addr, "::");
+				i += maxlen - 1;
+			} else {
+				r_strbuf_appendf (addr, "%x", words[i]); 
+			}
+		}
+		return r_strbuf_drain (addr);
+	}
+	return r_str_newf ("%x:%x:%x:%x:%x:%x:%x:%x",
+		words[0], words[1], words[2], words[3],
+		words[4], words[5], words[6], words[7]);
 }

--- a/libr/bin/format/pcap/pcap.h
+++ b/libr/bin/format/pcap/pcap.h
@@ -1,113 +1,110 @@
-#include <r_util.h>
-
 #ifndef _PCAP_H_
 #define _PCAP_H_
 
-// Definitions
-#define PCAP_MAGIC      0xa1b2c3d4 // Magic number for pcap files
-#define PCAP_NSEC_MAGIC 0xa1b23c4d // Modified pcap with nsec resolution
-#define LIBPCAP_MAGIC   0xa1b2cd34 // "libpcap" with Alexey Kuznetsoc's patches
+#include <r_types.h>
+#include <r_util.h>
 
-// The network field in the pcap file header
-typedef enum pcap_net {
-	NOLINK = 0,
-	ETHERNET = 1,
-	ETHERNET_3MB = 2,
-	AX_25 = 3,
-	PRONET = 4,
-	CHAOS = 5,
-	TOKEN_RING = 6,
-	ARCNET = 7,
-	SLIP = 8,
-	PPP = 9,
-	FDDI = 10,
-	RFC_1483_ATM_1 = 11,
-	RAW_IP_1 = 12,
-	BSDOS_SLIP_1 = 13,
-	BSDOS_PPP_1 = 14,
-	LINUX_ATM_CLASSICAL_IP = 19,
-	PPP_CISCO_HDLC = 50,
-	PPP_OVER_ETHERNET = 51,
-	SYMANTEC_FIREWALL = 99,
-	RFC_1483_ATM_2 = 100,
-	RAW_IP_2 = 101,
-	BSDOS_SLIP_2 = 102,
-	BSDOS_PPP_2 = 103,
-	BSDOS_CISCO_HDLC = 104,
-	_802_11 = 105,
-	LINUX_CLASSICAL_IP_ATM = 106,
-	FRAME_RELAY = 107,
-	OPENBSD_LOOPBACK = 108,
-	OPENBSD_IPSEC_ENC = 109,
-	CISCO_HDLC = 112,
-	LINUX_COOKED = 113,
-	LOCALTALK = 114,
-	OPENBSD_PFLOG = 117,
-	_802_11_PRISM = 119,
-	RFC_2625_IP_FIBRE_CHANNEL = 122,
-	SUNATM = 123,
-	_802_11_RADIOTAP = 127,
-	LINUX_ARCNET = 129,
-	APPLE_IP_IEEE_1394 = 138,
-	MTP2 = 140,
-	MTP3 = 141,
-	DOCSIS = 143,
-	IRDA = 144,
-	_802_11_AVS_HDR = 163,
-} pcap_net_t;
+// Magic number
+#define	PCAP_MAGIC_LE       0xd4c3b2a1 // Magic number for pcap files
+#define PCAP_MAGIC_BE       0xa1b2c3d4 // Magic number for pcap files
+#define PCAP_NSEC_MAGIC_LE  0x4d3cb2a1 // Modified pcap with nsec resolution
+#define PCAP_NSEC_MAGIC_BE  0xa1b23c4d // Modified pcap with nsec resolution
+#define LIBPCAP_MAGIC       0xa1b2cd34// "libpcap" with Alexey Kuznetsoc's patches
 
-// pcap file header
-typedef struct pcap_file_hdr {
+#define LINK_NOLINK	0
+#define LINK_ETHERNET	1
+#define LINK_ETHERNET_3MB	2
+#define LINK_AX_25	3
+#define LINK_PRONET	4
+#define LINK_CHAOS	5
+#define LINK_TOKEN_RING	6
+#define LINK_ARCNET	7
+#define LINK_SLIP	8
+#define LINK_PPP	9
+#define LINK_FDDI	10
+#define LINK_RFC_1483_ATM_1	11
+#define LINK_RAW_IP_1	12
+#define LINK_BSDOS_SLIP_1	13
+#define LINK_BSDOS_PPP_1	14
+#define LINK_LINUX_ATM_CLASSICAL_IP	19
+#define LINK_PPP_CISCO_HDLC	50
+#define LINK_PPP_OVER_ETHERNET	51
+#define LINK_SYMANTEC_FIREWALL	99
+#define LINK_RFC_1483_ATM_2	100
+#define LINK_RAW_IP_2	101
+#define LINK_BSDOS_SLIP_2	102
+#define LINK_BSDOS_PPP_2	103
+#define LINK_BSDOS_CISCO_HDLC	104
+#define LINK_802_11	105
+#define LINK_LINUX_CLASSICAL_IP_ATM	106
+#define LINK_FRAME_RELAY	107
+#define LINK_OPENBSD_LOOPBACK	108
+#define LINK_OPENBSD_IPSEC_ENC	109
+#define LINK_CISCO_HDLC	112
+#define LINK_LINUX_COOKED	113
+#define LINK_LOCALTALK	114
+#define LINK_OPENBSD_PFLOG	117
+#define LINK_802_11_PRISM	119
+#define LINK_RFC_2625_IP_FIBRE_CHANNEL	122
+#define LINK_SUNATM	123
+#define LINK_802_11_RADIOTAP	127
+#define LINK_LINUX_ARCNET	129
+#define LINK_APPLE_IP_IEEE_1394	138
+#define LINK_MTP2	140
+#define LINK_MTP3	141
+#define LINK_DOCSIS	143
+#define LINK_IRDA	144
+#define LINK_802_11_AVS_HDR	163
+
+#define NET_IPV4 0x0800
+#define NET_IPV6 0x86dd
+
+#define TRANSPORT_TCP 6
+
+// Global Header
+typedef struct pcap_hdr_s {
 	ut32 magic;			// magic number
 	ut16 version_major;
 	ut16 version_minor;
-	int this_zone;		// GMT to local correction
+	st32 this_zone;		// GMT to local correction
 	ut32 ts_accuracy;	// Accuracy of timestamps
 	ut32 max_pkt_len;	// Max length of captured packets in bytes
-	pcap_net_t network;	// Data link type
-} pcap_file_hdr_t;
-
-// Packet record header, always 16 bytes
-typedef struct pcak_pktrec_hdr {
-	ut32 ts_sec;	// Timestamp in seconds
-	ut32 ts_usec;	// Timestamp in usec (nanosec for PCAP_NSEC_MAGIC)
-	ut32 cap_len;	// Length of packet captured
-	ut32 orig_len;	// Original length of packet
-} pcap_pktrec_hdr_t;
+	ut32 network;	// Data link type
+} pcap_hdr_t;
 
 // Ethernet header, always 14 bytes
-typedef struct pcap_pktrec_ether {
-	ut8  dst[6];	// Destination MAC address
-	ut8  src[6];	// Source MAC address
-	ut16 type;	// 0x0080 = IPV4, 0xdd86 = IPV6 etc
-} pcap_pktrec_ether_t;
+typedef struct pcaprec_ether {
+	ut8 dst[6];	// Destination MAC address
+	ut8 src[6];	// Source MAC address
+	ut16 type;
+} pcaprec_ether_t;
 
 // IPV4 header, atleast 20 bytes
-typedef struct pcap_pktrec_ipv4 {
+typedef struct pcaprec_ipv4 {
 	ut8  ver_len;	// Upper nibble = version, lower = header len in 4-byte words
 	ut8  diff_serv;	// Differentiated services field
 	ut16 tot_len;	// Total length of IPV4 packet
 	ut16 id;
 	ut16 flag_frag;	// Upper 3 bits = flags, lower 13 = fragment offset
 	ut8  ttl;
-	ut8  protocol;	// 6 = TCP
+	ut8  protocol;
 	ut16 chksum;
 	ut32 src;		// Source IP
 	ut32 dst;		// Destination IP
-} pcap_pktrec_ipv4_t;
+} pcaprec_ipv4_t;
 
 // IPV6 header
-typedef struct pcap_pktrec_ipv6 {
+typedef struct pcaprec_ipv6 {
 	ut32 vc_flow;   // version, class, flow
 	ut16 plen;      // payload length
 	ut8  nxt;       // next header
 	ut8  hlim;      // hop limit
 	ut8  src[16];   // source address
-	ut8  dest[16];  // destination address
-} pcap_pktrec_ipv6_t;
+	ut8  dst[16];  // destination address
+} pcaprec_ipv6_t;
 
 // TCP header, 20 - 60 bytes
-typedef struct pcap_pktrec_tcp {
+typedef struct pcaprec_tcp {
 	ut16 src_port;	// Port on source
 	ut16 dst_port;	// Port on destination
 	ut32 seq_num;	// Sequence number
@@ -118,16 +115,47 @@ typedef struct pcap_pktrec_tcp {
 	ut16 chksum;
 	ut16 urgnt_ptr;	// Urgent
 	// Variable length options. Use hdr_len
-} pcap_pktrec_tcp_t;
+} pcaprec_tcp_t;
 
+// Record (Packet) Header
+typedef struct pcaprec_hdr_s {
+	ut32 ts_sec; // Timestamp in seconds
+	ut32 ts_usec;	// Timestamp in usec (nanosec for PCAP_NSEC_MAGIC)
+	ut32 incl_len;	// Length of packet captured
+	ut32 orig_len;	// Original length of packet
+} pcaprec_hdr_t;
 
-void read_pcap_file_hdr(pcap_file_hdr_t *hdr, const ut8 *buf, int swap_endian);
-void read_pcap_pktrec_hdr(pcap_pktrec_hdr_t *hdr, const ut8 *buf, int swap_endian);
-void read_pcap_pktrec_ether(pcap_pktrec_ether_t *hdr, const ut8 *buf, int swap_endian);
-void read_pcap_pktrec_ipv4(pcap_pktrec_ipv4_t *hdr, const ut8 *buf, int swap_endian);
-void read_pcap_pktrec_ipv6(pcap_pktrec_ipv6_t *hdr, const ut8 *buf, int swap_endian);
-void read_pcap_pktrec_tcp(pcap_pktrec_tcp_t *hdr, const ut8 *buf, int swap_endian);
+typedef struct pcaprec_s {
+	ut64 paddr;
+	pcaprec_hdr_t *hdr;
+	union {
+		pcaprec_ether_t *ether_hdr;
+	} link;
+	union {
+		pcaprec_ipv4_t *ipv4_hdr;
+		pcaprec_ipv6_t *ipv6_hdr;
+	} net;
+	union {
+		pcaprec_tcp_t *tcp_hdr;
+	} transport;
+	ut32 datasz;
+	ut8 *data;
+} pcaprec_t;
 
-const char* pcap_net_type (ut32 net);
+// The pcap object for RBinFile
+typedef struct pcap_obj_s {
+	pcap_hdr_t *header; // File header
+	RList/*<pcaprec_t>*/ *recs;
+	bool is_nsec; // nsec timestamp resolution?
+	bool bigendian;
+	RBuffer *b;
+} pcap_obj_t;
+
+pcap_obj_t *pcap_obj_new_buf(RBuffer *buf);
+void pcap_obj_free (pcap_obj_t *obj);
+void pcaprec_free(pcaprec_t *rec);
+void pcaprec_ether_sym_add(RList *list, pcaprec_t *rec, ut64 paddr);
+const char* pcap_network_string(ut32 network);
+const char *ipv6_addr_string (ut8 *addr);
 
 #endif  // _PCAP_H_

--- a/libr/bin/p/bin_pcap.c
+++ b/libr/bin/p/bin_pcap.c
@@ -1,435 +1,121 @@
 #include <r_bin.h>
 #include <r_lib.h>
-#include <r_types.h>
+
 #include "pcap.h"
 
-#define OPP_ENDIAN  1
-#define SAME_ENDIAN 0
-
-// The pcap object for RBinFile
-typedef struct pcap_obj {
-	struct pcap_file_hdr header;	// File header
-	bool is_nsec;					// nsec timestamp resolution?
-	int endian;	// Relative endianness (same or different from host)
-} pcap_obj_t;
-
-
-// Functions
-
-static RBinInfo *info(RBinFile *arch) {
-	if (!arch || !arch->o || !arch->o->bin_obj) {
-		return NULL;
-	}
+static RBinInfo *info(RBinFile *bf) {
+	r_return_val_if_fail (bf && bf->o && bf->o->bin_obj, NULL);
 	RBinInfo *ret = R_NEW0 (RBinInfo);
 	if (!ret) {
 		return NULL;
 	}
-	pcap_file_hdr_t *header = &((pcap_obj_t *) arch->o->bin_obj)->header;
-	ret->file = strdup (arch->file);
+	pcap_obj_t *obj = bf->o->bin_obj;
+	pcap_hdr_t *header = obj->header;
+	ret->file = strdup (bf->file);
 	ret->type = r_str_newf ("tcpdump capture file - version %d.%d (%s, "
-		"capture length %"PFMT32u ")", header->version_major,
-		header->version_minor, pcap_net_type (header->network),
-		header->max_pkt_len);
+	  "capture length %"PFMT32u ")",
+	header->version_major, header->version_minor,
+	pcap_network_string (header->network), header->max_pkt_len);
 	ret->rclass = strdup ("pcap");
 	return ret;
 }
 
-static bool check_bytes(const ut8 *buf, ut64 length) {
-	if (!buf || length < sizeof (pcap_file_hdr_t) || length == UT64_MAX) {
-		return false;
-	}
-	pcap_file_hdr_t *header = (pcap_file_hdr_t *) buf;
-	switch (header->magic) {
-	case PCAP_MAGIC:
-	case PCAP_NSEC_MAGIC:
+static bool check_buffer(RBuffer *b) {
+	r_return_val_if_fail (b, false);
+
+	switch (r_buf_read_be32_at (b, 0)) {
+	case PCAP_MAGIC_LE:
+	case PCAP_MAGIC_BE:
+	case PCAP_NSEC_MAGIC_LE:
+	case PCAP_NSEC_MAGIC_BE:
 		return true;
+		break;
 	}
-	switch (r_swap_ut32 (header->magic)) {
-	case PCAP_MAGIC:
-	case PCAP_NSEC_MAGIC:
+	return false;
+}
+
+static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
+	r_return_val_if_fail (bf && bin_obj && buf, false);
+
+	pcap_obj_t *obj = pcap_obj_new_buf (buf);
+	if (obj) {
+		*bin_obj = obj;
 		return true;
 	}
 	return false;
 }
 
-static bool check_buffer(RBuffer *b) {
-	ut8 buf[1024];
-	r_buf_read_at (b, 0, buf, sizeof (buf));
-	return check_bytes (buf, sizeof (buf));
-}
+static RList *symbols(RBinFile *bf) {
+	r_return_val_if_fail (bf && bf->o && bf->o->bin_obj, NULL);
 
-static void *load_bytes(RBinFile *arch, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb) {
-	if (!buf || !sz || sz < sizeof (pcap_file_hdr_t) || sz == UT64_MAX) {
+	RBinSymbol *ptr;
+	pcap_obj_t *obj = bf->o->bin_obj;
+	ut64 size = r_buf_size (obj->b);
+	if (size == 0 || size == UT64_MAX) {
 		return NULL;
 	}
-	struct pcap_obj *obj = NULL;
-	if (!(obj = R_NEW0 (pcap_obj_t))) {
-		return NULL;
-	}
-	memcpy (&obj->header, buf, sizeof (pcap_file_hdr_t));
-
-	obj->endian = SAME_ENDIAN;
-	switch (obj->header.magic) {
-	case PCAP_MAGIC:
-		obj->is_nsec = false;
-		break;
-	case PCAP_NSEC_MAGIC:
-		obj->is_nsec = true;
-		break;
-	default:
-		switch (r_swap_ut32 (obj->header.magic)) {
-		case PCAP_MAGIC:
-			obj->is_nsec = false;
-			break;
-		case PCAP_NSEC_MAGIC:
-			obj->is_nsec = true;
-			break;
-		default:
-			free (obj);
-			return NULL;
-		}
-		obj->endian = OPP_ENDIAN;
-	}
-	// Reload file header
-	read_pcap_file_hdr (&obj->header, buf, obj->endian);
-	return obj;
-}
-
-static void _read_tcp_sym(RList *list, const ut8 *buf, ut64 off, ut64 sz, ut64 tcplen, int endian) {
-	RBinSymbol *ptr = NULL;
-	if (off + sizeof (pcap_pktrec_tcp_t) > sz) {
-		return;
-	}
-	if (!(ptr = R_NEW0 (RBinSymbol))) {
-		return;
-	}
-	pcap_pktrec_tcp_t tcp;
-	read_pcap_pktrec_tcp (&tcp, &buf[off], endian);
-	ut64 tcp_data_len = tcplen - (((tcp.hdr_len >> 4) & 0x0F) * 4);
-	ptr->name = r_str_newf ("0x%x: Transmission Control Protocol, Src Port: %d, Dst"
-		" port: %d, Len: %d", off, tcp.src_port, tcp.dst_port,
-		tcp_data_len);
-	ptr->paddr = ptr->vaddr = off;
-	r_list_append (list, ptr);
-}
-
-static void _read_ipv4_sym(RList *list, const ut8 *buf, ut64 off, ut64 sz, int endian) {
-	RBinSymbol *ptr = NULL;
-	if (!(ptr = R_NEW0 (RBinSymbol))) {
-		return;
-	}
-	pcap_pktrec_ipv4_t ipv4;
-	read_pcap_pktrec_ipv4 (&ipv4, &buf[off], endian);
-	ptr->name = r_str_newf ("0x%"PFMT64x": IPV%d, Src: %d.%d.%d.%d, Dst: %d.%d.%d.%d",
-		off, (ipv4.ver_len >> 4) & 0x0F, (ipv4.src >> 24) & 0xFF,
-		(ipv4.src >> 16) & 0xFF, (ipv4.src >> 8) & 0xFF,
-		ipv4.src & 0xFF, (ipv4.dst >> 24) & 0xFF,
-		(ipv4.dst >> 16) & 0xFF, (ipv4.dst >> 8) & 0xFF,
-		ipv4.dst & 0xFF);
-	ptr->paddr = ptr->vaddr = off;
-	r_list_append (list, ptr);
-	if (off + ipv4.tot_len > sz) {
-		return;
-	}
-	off += (ipv4.ver_len & 0x0F) * 4;
-
-	// For now, if not TCP, continue. TODO others
-	switch (ipv4.protocol) {
-	case 6:
-		_read_tcp_sym (list, buf, off, sz, (ipv4.tot_len - ((ipv4.ver_len & 0x0F) * 4)), endian);
-	}
-}
-
-static void _write_ipv6_addr(const ut8 *addr, char *buf, int len) {
-	struct { int start, len; } best, cur;
-	ut16 words[8] = { 0 };
-	int i;
-	char *ptr = buf;
-	best.start = cur.start = -1;
-	best.len = cur.len = 0;
-	for (i = 0; i < 8; i++) {
-		words[i] = (addr[i * 2] << 4) | addr[i * 2 + 1];
-		if (words[i] == 0) {
-			if (cur.start == -1) {
-				cur.start = i;
-				cur.len = 1;
-			} else {
-				cur.len++;
-			}
-			continue;
-		}
-		if (cur.start != -1) {
-			if (best.start == -1 || cur.len > best.len) {
-				best.start = cur.start;
-				best.len = cur.len;
-			}
-			cur.start = -1;
-		}
-	}
-	if (best.start == -1 || cur.len > best.len) {
-		best.start = cur.start;
-		best.len = cur.len;
-	}
-	if (best.len < 2) {
-		best.start = -1;
-	}
-	for (i = 0; i < 8; i++) {
-		if (i == best.start) {
-			*ptr++ = ':';
-			continue;
-		}
-		if (best.start != -1 && i > best.start && i < best.start + best.len) {
-			continue;
-		}
-		if (i != 0) {
-			*ptr++ = ':';
-		}
-		ptr += snprintf (ptr, len - (ptr - buf), "%x", words[i]);
-	}
-}
-
-static void _read_ipv6_sym(RList *list, const ut8 *buf, ut64 off, ut64 sz, int endian) {
-	RBinSymbol *ptr = NULL;
-	if (!(ptr = R_NEW0 (RBinSymbol))) {
-		return;
-	}
-	char write_buf[256] = { 0 };
-	pcap_pktrec_ipv6_t ipv6;
-	int len;
-	read_pcap_pktrec_ipv6 (&ipv6, &buf[off], endian);
-	snprintf (write_buf, sizeof (write_buf) - 1, "0x%"PFMT64x": IPV6, Src: ", off);
-	len = strlen (write_buf);
-	_write_ipv6_addr (ipv6.src, write_buf + len, sizeof (write_buf) - len);
-	len += strlen (write_buf + len);
-	strcpy (write_buf + len, ", Dst: ");
-	len += strlen (write_buf + len);
-	_write_ipv6_addr (ipv6.dest, write_buf + len, sizeof (write_buf) - len);
-
-	if (!(ptr->name = strdup (write_buf))) {
-		free (ptr);
-		return;
-	}
-	ptr->paddr = ptr->vaddr = off;
-	r_list_append (list, ptr);
-	if (off + ipv6.plen + sizeof (pcap_pktrec_ipv6_t) > sz) {
-		return;
-	}
-	off += sizeof (pcap_pktrec_ipv6_t);
-
-	// For now, if not TCP, continue. TODO others
-	switch (ipv6.nxt) {
-	case 6:
-		_read_tcp_sym (list, buf, off, sz, ipv6.plen, endian);
-	}
-}
-
-static void _read_ether_sym(RList *list, const ut8 *buf, ut64 off, ut64 sz, int endian) {
-	RBinSymbol *ptr = NULL;
-	if (!(ptr = R_NEW0 (RBinSymbol))) {
-		return;
-	}
-	pcap_pktrec_ether_t ether;
-	read_pcap_pktrec_ether (&ether, &buf[off], endian);
-	ptr->name = r_str_newf ("0x%x: Ethernet, Src: %02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x
-		":%02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x ", Dst: %02"PFMT32x
-		":%02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x ":%02"PFMT32x
-		":%02"PFMT32x, off, ether.src[0], ether.src[1],
-		ether.src[2], ether.src[3], ether.src[4], ether.src[5],
-		ether.dst[0], ether.dst[1], ether.dst[2], ether.dst[3],
-		ether.dst[4], ether.dst[5]);
-	ptr->paddr = ptr->vaddr = off;
-	r_list_append (list, ptr);
-	off += sizeof (pcap_pktrec_ether_t);
-
-	// For now, if not IPV4, continue. TODO IPV6
-	switch (ether.type) {
-	case 0x08:
-		_read_ipv4_sym (list, buf, off, sz, endian);
-		break;
-	case 0xdd86:
-		_read_ipv6_sym (list, buf, off, sz, endian);
-	}
-}
-
-static RList *symbols(RBinFile *arch) {
-	RBinSymbol *ptr = NULL;
-	RList *ret = NULL;
-	pcap_obj_t *obj = NULL;
-	ut64 sz = 0;
-	ut64 off;
-	ut64 pkt_num = 0;
-	if (!arch || !arch->o || !arch->o->bin_obj || !arch->buf) {
-		return NULL;
-	}
-	obj = arch->o->bin_obj;
-	ut8 buf[1024]; // sizeof(pcap_file-hdr
-	r_buf_read_at (arch->buf, 0, buf, sizeof (buf));
-	sz = r_buf_size (arch->buf);
-	if (sz == 0 || sz == UT64_MAX) {
-		return NULL;
-	}
-	if (!(ret = r_list_new ())) {
+	RList *ret = r_list_newf (free);
+	if (!ret) {
 		return NULL;
 	}
 
 	// File header
-	if (!(ptr = R_NEW0 (RBinSymbol))) {
-		return ret;
+	ptr = R_NEW0 (RBinSymbol);
+	if (!ptr) {
+		r_list_free (ret);
+		return NULL;
 	}
 	ptr->name = r_str_newf ("tcpdump capture file - version %d.%d (%s, "
-		"capture length %"PFMT32u ")", obj->header.version_major,
-		obj->header.version_minor, pcap_net_type (obj->header.network),
-		obj->header.max_pkt_len);
+	  "capture length %"PFMT32u ")", obj->header->version_major,
+	obj->header->version_minor, pcap_network_string (obj->header->network),
+	obj->header->max_pkt_len);
 	ptr->paddr = ptr->vaddr = 0;
 	r_list_append (ret, ptr);
 
-	// Go through each packet
-	off = sizeof (pcap_file_hdr_t);
-	while (off <= sz - sizeof (pcap_pktrec_hdr_t)) {
-		pkt_num++;
-
-		// Frame header
-		if (!(ptr = R_NEW0 (RBinSymbol))) {
-			break;
+	// Go through each record packet
+	RListIter *iter;
+	pcaprec_t *rec;
+	switch (obj->header->network) {
+	case LINK_ETHERNET:
+		r_list_foreach (obj->recs, iter, rec) {
+			pcaprec_ether_sym_add (ret, rec, rec->paddr + sizeof (pcaprec_hdr_t));
 		}
-		pcap_pktrec_hdr_t pkthdr;
-		read_pcap_pktrec_hdr (&pkthdr, &buf[off], obj->endian);
-		ptr->name = r_str_newf ("0x%x: Frame %d, %d bytes on wire, %d bytes captured",
-			off, pkt_num, pkthdr.orig_len, pkthdr.cap_len);
-		ptr->paddr = ptr->vaddr = off;
-		r_list_append (ret, ptr);
-
-		// Check if rest of file is present. If not, break
-		if (off + sizeof (pcap_pktrec_hdr_t) + pkthdr.cap_len > sz) {
-			break;
-		}
-
-		// For now, if not ethernet, continue. TODO others
-		switch (obj->header.network) {
-		case ETHERNET:
-			_read_ether_sym (ret, buf, off + sizeof (pcap_pktrec_hdr_t), sz, obj->endian);
-		default:
-			break;
-		}
-		off += sizeof (pcap_pktrec_hdr_t) + pkthdr.cap_len;
+		break;
+	default:
+		break;
 	}
-
 	return ret;
 }
 
-static RList *strings(RBinFile *arch) {
-	RBinString *ptr = NULL;
-	RList *ret = NULL;
-	pcap_obj_t *obj = NULL;
-	char *tmp = NULL;
-	ut64 sz = 0;
-	ut64 off;
-	if (!arch || !arch->o || !arch->o->bin_obj || !arch->buf) {
+static RList *strings(RBinFile *bf) {
+	r_return_val_if_fail (bf && bf->o && bf->o->bin_obj, NULL);
+
+	RBinString *ptr;
+	pcap_obj_t *obj = bf->o->bin_obj;
+	RList *ret = r_list_newf (free);
+	if (!ret) {
 		return NULL;
 	}
-	obj = arch->o->bin_obj;
-	ut8 buf[1024];
-	r_buf_read_at (arch->buf, 0, buf, sizeof (buf));
-	sz = r_buf_size (arch->buf);
-	if (sz == 0 || sz == UT64_MAX) {
-		return NULL;
-	}
-	if (!(ret = r_list_new ())) {
-		return NULL;
-	}
-	if (!(tmp = malloc (obj->header.max_pkt_len + 1))) {
-		return ret;
-	}
 
-	// Go through each packet
-	off = sizeof (pcap_file_hdr_t);
-	while (off <= sz - sizeof (pcap_pktrec_hdr_t)) {
-		ut64 tmp_off = off;
-		// Frame header
-		pcap_pktrec_hdr_t pkthdr;
-		read_pcap_pktrec_hdr (&pkthdr, &buf[tmp_off], obj->endian);
-		if (tmp_off + sizeof (pcap_pktrec_hdr_t) + pkthdr.cap_len > sz) {
-			break;
+	RListIter *iter;
+	pcaprec_t *rec;
+	r_list_foreach (obj->recs, iter, rec) {
+		if (rec->data && *rec->data != 0) {
+			ptr = R_NEW0 (RBinString);
+			if (!ptr) {
+				r_list_free (ret);
+				return NULL;
+			}
+			ptr->string = strdup ((char *)rec->data);
+			ptr->paddr = ptr->vaddr = //XXX;
+			ptr->length = strlen (ptr->string);
+			ptr->size = ptr->length + 1;
+			ptr->type = R_STRING_TYPE_DETECT;
+			r_list_append (ret, ptr);
 		}
-		off += sizeof (pcap_pktrec_hdr_t) + pkthdr.cap_len;
-
-		// Ethernet data. For now, if not ethernet, continue. TODO others
-		if (obj->header.network != ETHERNET) {
-			continue;
-		}
-		tmp_off += sizeof (pcap_pktrec_hdr_t);
-		pcap_pktrec_ether_t ether;
-		read_pcap_pktrec_ether (&ether, &buf[tmp_off], obj->endian);
-
-		// IPV4 data. For now, if not IPV4, continue. TODO IPV6
-		if (ether.type != 0x08) {
-			continue;
-		}
-		tmp_off += sizeof (pcap_pktrec_ether_t);
-		pcap_pktrec_ipv4_t ipv4;
-		read_pcap_pktrec_ipv4 (&ipv4, &buf[tmp_off], obj->endian);
-		if (tmp_off + ipv4.tot_len > sz) {
-			continue;
-		}
-
-		// TCP header data. For now, if not TCP, continue. TODO others}
-		if (ipv4.protocol != 6) {
-			continue;
-		}
-		tmp_off += (ipv4.ver_len & 0x0F) * 4;
-		if (tmp_off + sizeof (pcap_pktrec_tcp_t) > sz) {
-			continue;
-		}
-		pcap_pktrec_tcp_t tcp;
-		read_pcap_pktrec_tcp (&tcp, &buf[tmp_off], obj->endian);
-		ut64 tcp_data_len = (ipv4.tot_len - ((ipv4.ver_len & 0x0F) * 4)) -
-				    (((tcp.hdr_len >> 4) & 0x0F) * 4);
-		if (tcp_data_len <= 1) {
-			continue;
-		}
-		tmp_off += ((tcp.hdr_len >> 4) & 0x0F) * 4;
-		if (tcp_data_len > obj->header.max_pkt_len || tmp_off + tcp_data_len > sz) {
-			continue;
-		}
-		size_t str_len;
-
-		memset (tmp, 0, obj->header.max_pkt_len);
-		strncpy (tmp, (const char *) &buf[tmp_off], tcp_data_len);
-		tmp[tcp_data_len] = '\0';
-		if (!(str_len = strlen (tmp))) {
-			continue;
-		}
-		if (!(ptr = R_NEW0 (RBinString))) {
-			break;
-		}
-		ptr->string = strdup (tmp);
-		ptr->paddr = ptr->vaddr = tmp_off;
-		ptr->length = str_len;
-		ptr->size = ptr->length + 1;
-		ptr->type = R_STRING_TYPE_DETECT;
-		r_list_append (ret, ptr);
 
 	}
-	free (tmp);
 	return ret;
-}
-
-static bool load(RBinFile *arch) {
-	if (!arch || !arch->o) {
-		return false;
-	}
-	ut64 size = r_buf_size (arch->buf);
-	ut8 *bytes = malloc (size);
-	if (!bytes || size == 0 || size == UT64_MAX) {
-		return false;
-	}
-	r_buf_read_at (arch->buf, 0, bytes, size);
-	arch->o->bin_obj = load_bytes (arch, bytes, size, arch->o->loadaddr, arch->sdb);
-	return arch->o->bin_obj != NULL;
-}
-
-static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
-	return load(bf);
 }
 
 RBinPlugin r_bin_plugin_pcap = {

--- a/types/include/pcap.h
+++ b/types/include/pcap.h
@@ -1,133 +1,161 @@
 #ifndef _PCAP_H_
 #define _PCAP_H_
 
-// Definitions
-enum pcap_const {
-	PCAP_MAGIC      = 0xa1b2c3d4, // Magic number for pcap files
-	PCAP_NSEC_MAGIC = 0xa1b23c4d, // Modified pcap with nsec resolution
-	LIBPCAP_MAGIC   = 0xa1b2cd34  // "libpcap" with Alexey Kuznetsoc's patches
-};
+#include <r_types.h>
+#include <r_util.h>
 
-// The network field in the pcap file header
-typedef enum pcap_net {
-	NOLINK = 0,
-	ETHERNET = 1,
-	ETHERNET_3MB = 2,
-	AX_25 = 3,
-	PRONET = 4,
-	CHAOS = 5,
-	TOKEN_RING = 6,
-	ARCNET = 7,
-	SLIP = 8,
-	PPP = 9,
-	FDDI = 10,
-	RFC_1483_ATM_1 = 11,
-	RAW_IP_1 = 12,
-	BSDOS_SLIP_1 = 13,
-	BSDOS_PPP_1 = 14,
-	LINUX_ATM_CLASSICAL_IP = 19,
-	PPP_CISCO_HDLC = 50,
-	PPP_OVER_ETHERNET = 51,
-	SYMANTEC_FIREWALL = 99,
-	RFC_1483_ATM_2 = 100,
-	RAW_IP_2 = 101,
-	BSDOS_SLIP_2 = 102,
-	BSDOS_PPP_2 = 103,
-	BSDOS_CISCO_HDLC = 104,
-	_802_11 = 105,
-	LINUX_CLASSICAL_IP_ATM = 106,
-	FRAME_RELAY = 107,
-	OPENBSD_LOOPBACK = 108,
-	OPENBSD_IPSEC_ENC = 109,
-	CISCO_HDLC = 112,
-	LINUX_COOKED = 113,
-	LOCALTALK = 114,
-	OPENBSD_PFLOG = 117,
-	_802_11_PRISM = 119,
-	RFC_2625_IP_FIBRE_CHANNEL = 122,
-	SUNATM = 123,
-	_802_11_RADIOTAP = 127,
-	LINUX_ARCNET = 129,
-	APPLE_IP_IEEE_1394 = 138,
-	MTP2 = 140,
-	MTP3 = 141,
-	DOCSIS = 143,
-	IRDA = 144,
-	_802_11_AVS_HDR = 163,
-} pcap_net_t;
+// Magic number
+#define	PCAP_MAGIC_LE       0xd4c3b2a1 // Magic number for pcap files
+#define PCAP_MAGIC_BE       0xa1b2c3d4 // Magic number for pcap files
+#define PCAP_NSEC_MAGIC_LE  0x4d3cb2a1 // Modified pcap with nsec resolution
+#define PCAP_NSEC_MAGIC_BE  0xa1b23c4d // Modified pcap with nsec resolution
+#define LIBPCAP_MAGIC       0xa1b2cd34// "libpcap" with Alexey Kuznetsoc's patches
 
-// pcap file header
-typedef struct pcap_file_hdr {
-	uint32_t magic;			// magic number
-	uint16_t version_major;
-	uint16_t version_minor;
-	int this_zone;		// GMT to local correction
-	uint32_t ts_accuracy;	// Accuracy of timestamps
-	uint32_t max_pkt_len;	// Max length of captured packets in bytes
-	pcap_net_t network;	// Data link type
-} pcap_file_hdr_t;
+#define LINK_NOLINK	0
+#define LINK_ETHERNET	1
+#define LINK_ETHERNET_3MB	2
+#define LINK_AX_25	3
+#define LINK_PRONET	4
+#define LINK_CHAOS	5
+#define LINK_TOKEN_RING	6
+#define LINK_ARCNET	7
+#define LINK_SLIP	8
+#define LINK_PPP	9
+#define LINK_FDDI	10
+#define LINK_RFC_1483_ATM_1	11
+#define LINK_RAW_IP_1	12
+#define LINK_BSDOS_SLIP_1	13
+#define LINK_BSDOS_PPP_1	14
+#define LINK_LINUX_ATM_CLASSICAL_IP	19
+#define LINK_PPP_CISCO_HDLC	50
+#define LINK_PPP_OVER_ETHERNET	51
+#define LINK_SYMANTEC_FIREWALL	99
+#define LINK_RFC_1483_ATM_2	100
+#define LINK_RAW_IP_2	101
+#define LINK_BSDOS_SLIP_2	102
+#define LINK_BSDOS_PPP_2	103
+#define LINK_BSDOS_CISCO_HDLC	104
+#define LINK_802_11	105
+#define LINK_LINUX_CLASSICAL_IP_ATM	106
+#define LINK_FRAME_RELAY	107
+#define LINK_OPENBSD_LOOPBACK	108
+#define LINK_OPENBSD_IPSEC_ENC	109
+#define LINK_CISCO_HDLC	112
+#define LINK_LINUX_COOKED	113
+#define LINK_LOCALTALK	114
+#define LINK_OPENBSD_PFLOG	117
+#define LINK_802_11_PRISM	119
+#define LINK_RFC_2625_IP_FIBRE_CHANNEL	122
+#define LINK_SUNATM	123
+#define LINK_802_11_RADIOTAP	127
+#define LINK_LINUX_ARCNET	129
+#define LINK_APPLE_IP_IEEE_1394	138
+#define LINK_MTP2	140
+#define LINK_MTP3	141
+#define LINK_DOCSIS	143
+#define LINK_IRDA	144
+#define LINK_802_11_AVS_HDR	163
 
-// Packet record header, always 16 bytes
-typedef struct pcak_pktrec_hdr {
-	uint32_t ts_sec;	// Timestamp in seconds
-	uint32_t ts_usec;	// Timestamp in usec (nanosec for PCAP_NSEC_MAGIC)
-	uint32_t cap_len;	// Length of packet captured
-	uint32_t orig_len;	// Original length of packet
-} pcap_pktrec_hdr_t;
+#define NET_IPV4 0x0800
+#define NET_IPV6 0x86dd
+
+#define TRANSPORT_TCP 6
+
+// Global Header
+typedef struct pcap_hdr_s {
+	ut32 magic;			// magic number
+	ut16 version_major;
+	ut16 version_minor;
+	st32 this_zone;		// GMT to local correction
+	ut32 ts_accuracy;	// Accuracy of timestamps
+	ut32 max_pkt_len;	// Max length of captured packets in bytes
+	ut32 network;	// Data link type
+} pcap_hdr_t;
 
 // Ethernet header, always 14 bytes
-typedef struct pcap_pktrec_ether {
-	uint8_t  dst[6];	// Destination MAC address
-	uint8_t  src[6];	// Source MAC address
-	uint16_t type;	// 0x0080 = IPV4, 0xdd86 = IPV6 etc
-} pcap_pktrec_ether_t;
+typedef struct pcaprec_ether {
+	ut8 dst[6];	// Destination MAC address
+	ut8 src[6];	// Source MAC address
+	ut16 type;
+} pcaprec_ether_t;
 
 // IPV4 header, atleast 20 bytes
-typedef struct pcap_pktrec_ipv4 {
-	uint8_t  ver_len;	// Upper nibble = version, lower = header len in 4-byte words
-	uint8_t  diff_serv;	// Differentiated services field
-	uint16_t tot_len;	// Total length of IPV4 packet
-	uint16_t id;
-	uint16_t flag_frag;	// Upper 3 bits = flags, lower 13 = fragment offset
-	uint8_t  ttl;
-	uint8_t  protocol;	// 6 = TCP
-	uint16_t chksum;
-	uint32_t src;		// Source IP
-	uint32_t dst;		// Destination IP
-} pcap_pktrec_ipv4_t;
+typedef struct pcaprec_ipv4 {
+	ut8  ver_len;	// Upper nibble = version, lower = header len in 4-byte words
+	ut8  diff_serv;	// Differentiated services field
+	ut16 tot_len;	// Total length of IPV4 packet
+	ut16 id;
+	ut16 flag_frag;	// Upper 3 bits = flags, lower 13 = fragment offset
+	ut8  ttl;
+	ut8  protocol;
+	ut16 chksum;
+	ut32 src;		// Source IP
+	ut32 dst;		// Destination IP
+} pcaprec_ipv4_t;
 
 // IPV6 header
-typedef struct pcap_pktrec_ipv6 {
-	uint32_t vc_flow;   // version, class, flow
-	uint16_t plen;      // payload length
-	uint8_t  nxt;       // next header
-	uint8_t  hlim;      // hop limit
-	uint8_t  src[16];   // source address
-	uint8_t  dest[16];  // destination address
-} pcap_pktrec_ipv6_t;
+typedef struct pcaprec_ipv6 {
+	ut32 vc_flow;   // version, class, flow
+	ut16 plen;      // payload length
+	ut8  nxt;       // next header
+	ut8  hlim;      // hop limit
+	ut8  src[16];   // source address
+	ut8  dst[16];  // destination address
+} pcaprec_ipv6_t;
 
 // TCP header, 20 - 60 bytes
-typedef struct pcap_pktrec_tcp {
-	uint16_t src_port;	// Port on source
-	uint16_t dst_port;	// Port on destination
-	uint32_t seq_num;	// Sequence number
-	uint32_t ack_num;	// Ack number
-	uint8_t  hdr_len;	// Length of TCP header
-	uint16_t flags;		// TCP flags
-	uint16_t win_sz;	// Window size
-	uint16_t chksum;
-	uint16_t urgnt_ptr;	// Urgent
+typedef struct pcaprec_tcp {
+	ut16 src_port;	// Port on source
+	ut16 dst_port;	// Port on destination
+	ut32 seq_num;	// Sequence number
+	ut32 ack_num;	// Ack number
+	ut8  hdr_len;	// Length of TCP header
+	ut16 flags;		// TCP flags
+	ut16 win_sz;	// Window size
+	ut16 chksum;
+	ut16 urgnt_ptr;	// Urgent
 	// Variable length options. Use hdr_len
-} pcap_pktrec_tcp_t;
+} pcaprec_tcp_t;
 
+// Record (Packet) Header
+typedef struct pcaprec_hdr_s {
+	ut32 ts_sec; // Timestamp in seconds
+	ut32 ts_usec;	// Timestamp in usec (nanosec for PCAP_NSEC_MAGIC)
+	ut32 incl_len;	// Length of packet captured
+	ut32 orig_len;	// Original length of packet
+} pcaprec_hdr_t;
 
-void read_pcap_file_hdr(pcap_file_hdr_t *hdr, const uint8_t *buf, int swap_endian);
-void read_pcap_pktrec_hdr(pcap_pktrec_hdr_t *hdr, const uint8_t *buf, int swap_endian);
-void read_pcap_pktrec_ether(pcap_pktrec_ether_t *hdr, const uint8_t *buf, int swap_endian);
-void read_pcap_pktrec_ipv4(pcap_pktrec_ipv4_t *hdr, const uint8_t *buf, int swap_endian);
-void read_pcap_pktrec_ipv6(pcap_pktrec_ipv6_t *hdr, const uint8_t *buf, int swap_endian);
-void read_pcap_pktrec_tcp(pcap_pktrec_tcp_t *hdr, const uint8_t *buf, int swap_endian);
+typedef struct pcaprec_s {
+	ut64 paddr;
+	pcaprec_hdr_t *hdr;
+	union {
+		pcaprec_ether_t *ether_hdr;
+	} link;
+	union {
+		pcaprec_ipv4_t *ipv4_hdr;
+		pcaprec_ipv6_t *ipv6_hdr;
+	} net;
+	union {
+		pcaprec_tcp_t *tcp_hdr;
+	} transport;
+	ut32 datasz;
+	ut8 *data;
+} pcaprec_t;
 
-const char* pcap_net_type (uint32_t net);
+// The pcap object for RBinFile
+typedef struct pcap_obj_s {
+	pcap_hdr_t *header; // File header
+	RList/*<pcaprec_t>*/ *recs;
+	bool is_nsec; // nsec timestamp resolution?
+	bool bigendian;
+	RBuffer *b;
+} pcap_obj_t;
+
+pcap_obj_t *pcap_obj_new_buf(RBuffer *buf);
+void pcap_obj_free (pcap_obj_t *obj);
+void pcaprec_free(pcaprec_t *rec);
+void pcaprec_ether_sym_add(RList *list, pcaprec_t *rec, ut64 paddr);
+const char* pcap_network_string(ut32 network);
+const char *ipv6_addr_string (ut8 *addr);
 
 #endif  // _PCAP_H_


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Fix pcap plugin to make it work again. Previously, it looks for RBinObject in `arch->o` which is not initialized to assign `bin_obj` to `arch->o->bin_obj` and it should use the `void **bin_obj` parameter in `load_buffer` instead. Therefore, it always `return false` and prevents the plugin from parsing the file.
```
static bool load(RBinFile *arch) {	
	if (!arch || !arch->o) {	
		return false;	
	}
```

Besides, I rewrite most parts to use `r_read_*` and `r_buf_read_*` to ensure endianness is correct and store the results in its `bin_obj` `pcap_obj_t` so I could use it later for testing remote debugging radareorg/ideas#60.

**Test plan**

1. Install the plugin. `r2pm install pcap`
2. Open a .pcap file `r2 test/bins/pcap/sample0.pcap`
3. List symbols `is` and compare them on Wireshark or other similar applications.
4. List strings `iz`