### PR TITLE
atombios: Make plugins compile again && GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        repository: radareorg/radare2
+        repository: zamaudio/radare2
+        ref: r2pm-gitmaster
         path: ./radare2
     - name: Install dependencies
       run: sudo apt-get --assume-yes install wget unzip python3-wheel python3-setuptools build-essential python3-pip && sudo pip3 install meson ninja

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build radare2 extras and r2pipe
     runs-on: ubuntu-latest
     env:
-      TESTS: 'armthumb baleful bcl ba2 blackfin blessr2 keystone-lib keystone lang-duktape mc6809 microblaze msil pcap ppcdisasm psosvm swf unicorn-lib unicorn vc4 x86udis x86bea x86tab x86olly x86zyan z80-nc'
+      TESTS: 'armthumb atombios baleful bcl ba2 blackfin blessr2 keystone-lib keystone lang-duktape mc6809 microblaze msil pcap ppcdisasm psosvm swf unicorn-lib unicorn vc4 x86udis x86bea x86tab x86olly x86zyan z80-nc'
       R2PIPE_TESTS: 'r2pipe-go r2pipe-js r2pipe-py'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+  
+  pull_request:
+
+
+jobs:
+
+  build-extras:
+    name: Build radare2 extras and r2pipe
+    runs-on: ubuntu-latest
+    env:
+      TESTS: 'armthumb baleful bcl ba2 blackfin blessr2 keystone-lib keystone lang-duktape mc6809 microblaze msil pcap ppcdisasm psosvm swf unicorn-lib unicorn vc4 x86udis x86bea x86tab x86olly x86zyan z80-nc'
+      R2PIPE_TESTS: 'r2pipe-go r2pipe-js r2pipe-py'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: radareorg/radare2
+        path: ./radare2
+    - name: Install dependencies
+      run: sudo apt-get --assume-yes install wget unzip python3-wheel python3-setuptools build-essential python3-pip && sudo pip3 install meson ninja
+    - name: Install radare2
+      run: |
+        export PATH=$PATH:/usr/local/bin
+        meson --prefix=/usr --buildtype=release build && ninja -C build && sudo ninja -C build install
+      working-directory: radare2
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        path: ./radare2-extras
+    - name: Init r2pm
+      run: r2pm init
+    - name: Compile and install plugins
+      run: |
+        set -e
+        export R2PM_GITDIR=./
+        export R2PM_GITMASTER=`cd radare2-extras; git describe --always --all`
+        for p in $TESTS ; do
+          echo $p
+          r2pm -i $p
+        done
+        set +e
+    - name: Compile and install r2pipe
+      run: |
+        set -e
+        export R2PM_GITDIR=./
+        export R2PM_GITMASTER=`cd radare2-extras; git describe --always --all`
+        for p in $R2PIPE_TESTS ; do
+          echo $p
+          r2pm -i $p
+        done
+        set +e
+

--- a/libr/anal/p/anal_atombios.c
+++ b/libr/anal/p/anal_atombios.c
@@ -411,7 +411,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 				return op->size;
 			}
 			op->cond = R_ANAL_COND_AL;
-			op->jump = cursect->paddr - 6 + r_read_at_le16(b, 1);
+			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->eob = true;
 			esilprintf (op, "0x%08x,pc,=", op->jump);
 		} break;
@@ -423,7 +423,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 				return op->size;
 			}
 			op->cond = R_ANAL_COND_EQ;
-			op->jump = cursect->paddr - 6 + r_read_at_le16(b, 1);
+			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
 			esilprintf (op, "$z,?{,0x%08x,pc,=,}", op->jump);
@@ -436,7 +436,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 				return op->size;
 			}
 			op->cond = R_ANAL_COND_LT;
-			op->jump = cursect->paddr - 6 + r_read_at_le16(b, 1);
+			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
 			esilprintf (op, "$of,$sf,!=,?{,0x%08x,pc,=,}", op->jump);
@@ -449,7 +449,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 				return op->size;
 			}
 			op->cond = R_ANAL_COND_GT;
-			op->jump = cursect->paddr - 6 + r_read_at_le16(b, 1);
+			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
 			esilprintf (op, "$z,!,$of,$sf,==,&,?{,0x%08x,pc,=,}", op->jump);
@@ -462,7 +462,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 				return op->size;
 			}
 			op->cond = R_ANAL_COND_LE;
-			op->jump = cursect->paddr - 6 + r_read_at_le16(b, 1);
+			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
 			esilprintf (op, "$z,$of,$sf,!=,|,?{,0x%08x,pc,=,}", op->jump);
@@ -475,7 +475,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 				return op->size;
 			}
 			op->cond = R_ANAL_COND_GE;
-			op->jump = cursect->paddr - 6 + r_read_at_le16(b, 1);
+			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
 			esilprintf (op, "$of,$sf,==,?{,0x%08x,pc,=,}", op->jump);
@@ -488,7 +488,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 				return op->size;
 			}
 			op->cond = R_ANAL_COND_NE;
-			op->jump = cursect->paddr - 6 + r_read_at_le16(b, 1);
+			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
 			esilprintf (op, "$z,!,?{,0x%08x,pc,=,}", op->jump);

--- a/libr/anal/p/anal_atombios.c
+++ b/libr/anal/p/anal_atombios.c
@@ -8,8 +8,6 @@
 
 #include "../../asm/arch/atombios/atombios.h"
 
-#define R_IPI static
-
 typedef struct {
 	_RAnalOpType optype;
 	const char *reg;
@@ -155,60 +153,7 @@ atombios_ops_t atombios_ops[256] = {
 	[0xff] = { R_ANAL_OP_TYPE_ILL, NULL	}, // not implemented (reserved)
 };
 
-static int atombios_analyze_fns(RAnal *anal, ut64 start, ut64 end, int reftype, int depth) {
-	ut8 i;
-	const RList *sects;
-	char name[256] = {0};
-	char namesym[256] = {0};
-
-	if (!(sects = r_bin_get_sections(anal->binb.bin))) {
-		return 0;
-	}
-	for (i = 0; i < N_TABLES_CMD; i++) {
-		RBinSection *sect = (RBinSection *)r_list_get_n(sects, i);
-
-		if (!sect)
-			continue;
-		else if (!sect->paddr)
-			continue;
-
-		sprintf (name, "fcn.%s", index_command_table[i]);
-		r_anal_fcn_add(anal, sect->paddr, sect->size, name, R_ANAL_FCN_TYPE_FCN, NULL);
-
-		// Add locs for local data blocks:
-		// eg:
-		// 0x0000c236      5b             ret
-		// 0x0000c237      7a2600000000.  bindata  38 bytes
-		// ;end section
-
-		ut32 paddr = 0;
-		ut32 size = 0;
-		ut8 *buf = r_buf_get_at (anal->binb.bin->cur->buf, sect->paddr + sect->size - 1, NULL);
-		ut8 *orig = r_buf_get_at (anal->binb.bin->cur->buf, 0, NULL);
-		if (*buf == 0x5b) {
-			// No data here
-			continue;
-		} else {
-			// We have a data block at the end of the fcn.
-			while (r_read_le16(buf) != 0x7a5b) {
-				--buf;
-				++size;
-			}
-			if (buf - orig < sect->paddr) {
-				// WTF not in function
-				continue;
-			}
-			buf += 2;
-			--size;
-			paddr = buf - orig;
-			sprintf (namesym, "sym.%s", index_command_table[i]);
-			r_anal_fcn_add (anal, paddr, size, namesym, R_ANAL_FCN_TYPE_SYM, NULL);
-		}
-	}
-	return 0;
-}
-
-static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len) {
+static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RAnalOpMask unused) {
 	if (!op)
 		return 1;
 	memset (op, 0, sizeof (RAnalOp));
@@ -418,9 +363,8 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 
 	// op ds (imm data table)
 	case 0x7a:
-		{
-
-		} break;
+		op->size = 3;// + r_read_at_le16(b, 1);
+		break;
 
 	// op imm8
 	case 0x50:
@@ -892,7 +836,7 @@ static int archinfo(RAnal *anal, int query) {
 	}
 }
 
-static int set_reg_profile(RAnal *anal) {
+static bool set_reg_profile(RAnal *anal) {
 	const char *p =
 	"=PC    pc\n"
 	"=SP    sp\n"
@@ -1114,7 +1058,6 @@ RAnalPlugin r_anal_plugin_atombios = {
 	.arch = "atombios",
 	.bits = 32 | 64,
 	.op = &atombios_op,
-	.analyze_fns = atombios_analyze_fns,
 	.archinfo = archinfo,
 };
 

--- a/libr/anal/p/anal_atombios.c
+++ b/libr/anal/p/anal_atombios.c
@@ -155,11 +155,15 @@ atombios_ops_t atombios_ops[256] = {
 
 static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int len, RAnalOpMask unused) {
 	if (!op)
-		return 1;
+		return -1;
 	memset (op, 0, sizeof (RAnalOp));
 	op->nopcode = 1;
 	op->size = atombios_inst_len (b);
 	op->type = atombios_ops[*b].optype;
+	if (len < op->size) {
+		op->type = R_ANAL_OP_TYPE_ILL;
+		return -1;
+	}
 
 	if (*b > 0x7a) {
 		op->type = R_ANAL_OP_TYPE_ILL;

--- a/libr/asm/arch/atombios/atombios.c
+++ b/libr/asm/arch/atombios/atombios.c
@@ -592,12 +592,16 @@ int atombios_inst_len(const ut8 *buf) {
 	return size;
 }
 
-int atombios_disassemble(const ut8 *inbuf, char *outbuf) {
+int atombios_disassemble(const ut8 *inbuf, int len, char *outbuf) {
 	const ut8 *d = inbuf;
 	ut8 size = 0;
 
 	if (optable[*d].process) {
 		size = optable[*d].process (d, outbuf);
+		if (size > len) {
+			sprintf (outbuf, "<truncated>");
+			size = 1;
+		}
 	} else {
 		sprintf (outbuf, "<unknown opcode> %02x", *d);
 		size = 1;

--- a/libr/asm/arch/atombios/atombios.h
+++ b/libr/asm/arch/atombios/atombios.h
@@ -68,7 +68,7 @@ typedef struct {
 
 
 int atombios_inst_len(const ut8 *buf);
-int atombios_disassemble(const ut8 *inbuf, char *outbuf);
+int atombios_disassemble(const ut8 *inbuf, int len, char *outbuf);
 const char *get_index (int type, int val);
 
 extern const char *align_source_esil[];

--- a/libr/asm/p/asm_atombios.c
+++ b/libr/asm/p/asm_atombios.c
@@ -9,7 +9,7 @@
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
 	char res[1024];
 	res[0] = 0;
-	op->size = atombios_disassemble (buf, res);
+	op->size = atombios_disassemble (buf, len, res);
 	r_strbuf_set (&op->buf_asm, res);
 	return op->size;
 }

--- a/libr/asm/p/asm_atombios.c
+++ b/libr/asm/p/asm_atombios.c
@@ -7,7 +7,10 @@
 #include "../arch/atombios/atombios.h"
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {
-	op->size = atombios_disassemble (buf, r_asm_op_get_asm (op));
+	char res[1024];
+	res[0] = 0;
+	op->size = atombios_disassemble (buf, res);
+	r_strbuf_set (&op->buf_asm, res);
 	return op->size;
 }
 

--- a/libr/asm/p/atombios.mk
+++ b/libr/asm/p/atombios.mk
@@ -6,4 +6,4 @@ STATIC_OBJ+=${OBJ_ATOMBIOS}
 
 ALL_TARGETS+=${TARGET_ATOMBIOS}
 ${TARGET_ATOMBIOS}: ${OBJ_ATOMBIOS}
-	${CC} -g $(call libname,asm_atombios) ${LDFLAGS} ${CFLAGS} -o ${TARGET_ATOMBIOS} ${OBJ_ATOMBIOS}
+	${CC} -g $(call libname,asm_atombios) ${LDFLAGS} ${CFLAGS} -o ${TARGET_ATOMBIOS} ${OBJ_ATOMBIOS} -lr_util

--- a/libr/bin/format/atombios/atombios.h
+++ b/libr/bin/format/atombios/atombios.h
@@ -1,0 +1,13 @@
+#ifndef _ATOMBIOS_H_
+#define _ATOMBIOS_H_
+
+#include <r_types.h>
+#include <r_util.h>
+
+// The atombios object for RBinFile
+typedef struct atombios_obj_s {
+        //atombios_hdr_t *header;
+        RBuffer *b;
+} atombios_obj_t;
+
+#endif

--- a/libr/bin/p/bin_atombios.c
+++ b/libr/bin/p/bin_atombios.c
@@ -50,8 +50,7 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 		if (!cmdtableoffs[i]) {
 			cmdtablesize[i] = 0;
 		} else {
-			cmdtablesize[i] = r_buf_read_le16_at (b, cmdtableoffs[i]) - 6;
-			cmdtableoffs[i] += 6;
+			cmdtablesize[i] = r_buf_read_le16_at (b, cmdtableoffs[i]);
 		}
 	}
 
@@ -60,8 +59,7 @@ static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr,
 		if (!datatableoffs[i]) {
 			datatablesize[i] = 0;
 		} else {
-			datatablesize[i] = r_buf_read_le16_at (b, datatableoffs[i]) - 4;
-			datatableoffs[i] += 4;
+			datatablesize[i] = r_buf_read_le16_at (b, datatableoffs[i]);
 		}
 	}
 	return true;
@@ -106,8 +104,15 @@ static RList* symbols(RBinFile *bf) {
 	/* Data table symbols */
 	for (i = 0; i < N_TABLES_DATA; i++) {
 		if (datatablesize[i])
-			addsym (ret, index_data_table[i], datatableoffs[i], datatablesize[i]);
+			addsym (ret, index_data_table[i], datatableoffs[i] + 4, datatablesize[i] - 4);
 	}
+
+	/* Command table symbols */
+	for (i = 0; i < N_TABLES_CMD; i++) {
+		if (cmdtablesize[i])
+			addsym (ret, index_command_table[i], cmdtableoffs[i] + 6, cmdtablesize[i] - 6);
+	}
+
 	return ret;
 }
 
@@ -180,8 +185,8 @@ static RList* entries(RBinFile *arch) {
 	if (!(ptr = R_NEW0 (RBinAddr)))
 		return ret;
 
-	ptr->paddr = cmdtableoffs[0];
-	ptr->vaddr = cmdtableoffs[0];
+	ptr->paddr = cmdtableoffs[0] + 6;
+	ptr->vaddr = cmdtableoffs[0] + 6;
 	r_list_append(ret, ptr);
 
 	return ret;

--- a/libr/bin/p/bin_atombios.c
+++ b/libr/bin/p/bin_atombios.c
@@ -6,6 +6,7 @@
 #include <r_bin.h>
 #include <r_endian.h>
 #include "../../asm/arch/atombios/atombios.h"
+#include "atombios.h"
 
 static ut16 header;
 static ut16 mastercmdoffset;
@@ -15,56 +16,55 @@ static ut32 cmdtablesize[N_TABLES_CMD];
 static ut32 datatableoffs[N_TABLES_DATA];
 static ut32 datatablesize[N_TABLES_DATA];
 
-static bool check_bytes(const ut8 *buf, ut64 length) {
-	if (!buf || length < 0x70)
+static bool check_buffer(RBuffer *b) {
+	if (!b || r_buf_size (b) < 0x70)
 		return false;
 
-	header = r_read_at_le16(buf, HEADER_OFFSET);
-	if (memcmp (buf + header + 4, ATOM_MAGIC, 4))
+	ut8 magic[4] = {0};
+	header = r_buf_read_le16_at (b, HEADER_OFFSET);
+	r_buf_read_at (b, header + 4, magic, 4);
+	if (memcmp (magic, ATOM_MAGIC, 4))
 		return false;
 
 	return true;
 }
 
-static bool load_bytes(RBinFile *bf, void **bin_obj, const ut8 *buf, ut64 sz, ut64 loadaddr, Sdb *sdb){
-	ut8 i;
-	if (!check_bytes(buf, sz))
+static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr, Sdb *sdb){
+	if (!check_buffer(b))
 		return false;
 
-	mastercmdoffset = r_read_at_le16(buf, header + 30) + 4;
-	masterdataoffset = r_read_at_le16(buf, header + 32) + 4;
+	ut8 i;
+	atombios_obj_t *obj = R_NEW0 (atombios_obj_t);
+	if (!obj) {
+		return false;
+	} else {
+		obj->b = r_buf_ref (b);
+                *bin_obj = obj;
+	}
 
+	mastercmdoffset = r_buf_read_le16_at (b, header + 30) + 4;
+	masterdataoffset = r_buf_read_le16_at (b, header + 32) + 4;
 
 	for (i = 0; i < N_TABLES_CMD; i++) {
-		cmdtableoffs[i] = r_read_at_le16 (buf, mastercmdoffset + i * sizeof (ut16));
+		cmdtableoffs[i] = r_buf_read_le16_at (b, mastercmdoffset + i * sizeof (ut16));
 		if (!cmdtableoffs[i]) {
 			cmdtablesize[i] = 0;
 		} else {
-			cmdtablesize[i] = r_read_at_le16 (buf, cmdtableoffs[i]) - 6;
+			cmdtablesize[i] = r_buf_read_le16_at (b, cmdtableoffs[i]) - 6;
 			cmdtableoffs[i] += 6;
 		}
 	}
 
 	for (i = 0; i < N_TABLES_DATA; i++) {
-		datatableoffs[i] = r_read_at_le16 (buf, masterdataoffset + i * sizeof (ut16));
+		datatableoffs[i] = r_buf_read_le16_at (b, masterdataoffset + i * sizeof (ut16));
 		if (!datatableoffs[i]) {
 			datatablesize[i] = 0;
 		} else {
-			datatablesize[i] = r_read_at_le16 (buf, datatableoffs[i]) - 4;
+			datatablesize[i] = r_buf_read_le16_at (b, datatableoffs[i]) - 4;
 			datatableoffs[i] += 4;
 		}
 	}
 	return true;
-}
-
-static bool load(RBinFile *bf) {
-        const ut8 *bytes = bf ? r_buf_buffer (bf->buf) : NULL;
-        ut64 sz = bf ? r_buf_size (bf->buf): 0;
-
-        if (!bf || !bf->o) {
-                return false;
-        }
-        return load_bytes (bf, &bf->o->bin_obj, bytes, sz, bf->o->loadaddr, bf->sdb);
 }
 
 static RBinInfo* info(RBinFile *arch) {
@@ -81,67 +81,66 @@ static RBinInfo* info(RBinFile *arch) {
 	ret->arch = strdup ("atombios");
 	ret->bits = 32;
 	ret->has_va = false;
-	ret->dbg_info = 0;
+	ret->dbg_info = 1;
 	ret->has_nx = false;
 
 	return ret;
 }
 
 static void addsym(RList *ret, const char *name, ut64 addr, ut32 size) {
-        RBinSymbol *ptr = R_NEW0 (RBinSymbol);
-        if (!ptr) return;
-        ptr->name = strdup (name? name: "");
-        ptr->paddr = ptr->vaddr = addr;
-        ptr->size = size;
-        ptr->ordinal = 0;
-        r_list_append (ret, ptr);
+	RBinSymbol *ptr = R_NEW0 (RBinSymbol);
+	if (!ptr) return;
+	ptr->name = strdup (name? name: "dummy");
+	ptr->paddr = ptr->vaddr = addr;
+	ptr->size = size;
+	ptr->ordinal = 0;
+	r_list_append (ret, ptr);
 }
 
 static RList* symbols(RBinFile *bf) {
 	ut8 i;
         RList *ret = NULL;
-        if (!(ret = r_list_newf (free))) {
+        if (!(ret = r_list_newf (free)))
                 return NULL;
-        }
 
 	/* Data table symbols */
 	for (i = 0; i < N_TABLES_DATA; i++) {
-		if (datatableoffs[i])
+		if (datatablesize[i])
 			addsym (ret, index_data_table[i], datatableoffs[i], datatablesize[i]);
 	}
 	return ret;
 }
 
-static RList* sections(RBinFile *arch) {
+static RList* sections(RBinFile *bf) {
 	ut8 i;
 	ut16 sz = 0;
 	RList *ret = NULL;
 	RBinSection *sect;
+	//RBuffer *b = bf->o->bin_obj;
 
-	if (!(ret = r_list_new()))
+	if (!(ret = r_list_newf (free)))
 		return NULL;
 
 	/* Command table sections */
 	for (i = 0; i < N_TABLES_CMD; i++) {
 		sz = cmdtablesize[i];
 		if (!(sect = R_NEW0 (RBinSection))) {
-			return false;
+			return NULL;
 		}
 		if (cmdtableoffs[i]) {
-			strcpy (sect->name, index_command_table[i]);
+			sect->name = strdup (index_command_table[i]);
 			sect->paddr = cmdtableoffs[i];
 			sect->vaddr = cmdtableoffs[i];
 			sect->size = sz;
 			sect->vsize = sz;
-			sect->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
+			//TODO sect->srwx = R_BIN_SCN_READABLE | R_BIN_SCN_EXECUTABLE;
 			r_list_append (ret, sect);
 		} else {
-			strcpy (sect->name, "dummy");
+			sect->name = strdup ("dummy");
 			sect->paddr = 0;
 			sect->vaddr = 0;
 			sect->size = 0;
 			sect->vsize = 0;
-			sect->srwx = 0;
 			r_list_append (ret, sect);
 		}
 	}
@@ -150,23 +149,22 @@ static RList* sections(RBinFile *arch) {
 	for (i = 0; i < N_TABLES_DATA; i++) {
 		sz = datatablesize[i];
 		if (!(sect = R_NEW0 (RBinSection))) {
-			return false;
+			return NULL;
 		}
 		if (datatableoffs[i]) {
-			strcpy (sect->name, index_data_table[i]);
+			sect->name = strdup (index_data_table[i]);
 			sect->paddr = datatableoffs[i];
 			sect->vaddr = datatableoffs[i];
 			sect->size = sz;
 			sect->vsize = sz;
-			sect->srwx = R_BIN_SCN_READABLE;
+			//TODO sect->srwx = R_BIN_SCN_READABLE;
 			r_list_append (ret, sect);
 		} else {
-			strcpy (sect->name, "dummy");
+			sect->name = strdup ("dummy");
 			sect->paddr = 0;
 			sect->vaddr = 0;
 			sect->size = 0;
 			sect->vsize = 0;
-			sect->srwx = 0;
 			r_list_append (ret, sect);
 		}
 	}
@@ -191,11 +189,10 @@ static RList* entries(RBinFile *arch) {
 
 RBinPlugin r_bin_plugin_atombios = {
 	.name = "atombios",
-	.desc = "AtomBIOS",
+	.desc = "AtomBIOS binary format parser",
 	.license = "LGPL3",
-	.load = &load,
-	.load_bytes = &load_bytes,
-	.check_bytes = &check_bytes,
+	.load_buffer = &load_buffer,
+	.check_buffer = &check_buffer,
 	.entries = &entries,
 	.sections = &sections,
 	.symbols = &symbols,
@@ -206,6 +203,7 @@ RBinPlugin r_bin_plugin_atombios = {
 RLibStruct radare_plugin = {
 	.type = R_LIB_TYPE_BIN,
 	.data = &r_bin_plugin_atombios,
-	.version = R2_VERSION
+	.version = R2_VERSION,
+	.pkgname = "atombios",
 };
 #endif


### PR DESCRIPTION
This makes atombios asm/anal/bin plugins all work again.  Previously they would not compile.

![image](https://user-images.githubusercontent.com/3164348/93406389-e1014980-f8d2-11ea-9212-51dbdcfe5236.png)

