### PR TITLE
Fix Vector35 ARM64 plugin build

### DIFF
--- a/Makefile.acr
+++ b/Makefile.acr
@@ -29,10 +29,11 @@ arm64v35:
 	$(MAKE) -C libr/anal arm64v35
 
 arm64v35-install:
-	cp -f libr/{asm,anal}/p/a*arm_v35.$(LIBEXT) $(R2PM_PLUGDIR)
+	cp -f libr/asm/p/asm_arm_v35.$(LIBEXT) $(R2PM_PLUGDIR)
+	cp -f libr/anal/p/anal_arm_v35.$(LIBEXT) $(R2PM_PLUGDIR)
 
 arm64v35-uninstall:
-	rm -f $(R2PM_PLUGDIR)/a*arm_v35.$(LIBEXT)
+	rm -f $(R2PM_PLUGDIR)/a*_arm_v35.$(LIBEXT)
 
 #	@echo "  install-yara{2,3}  - install Yara 2 or 3 from Git"
 

--- a/libr/anal/p/anal_arm_v35.c
+++ b/libr/anal/p/anal_arm_v35.c
@@ -9,7 +9,7 @@
 #include "../../asm/arch/arm/v35arm64/disassembler/operations.h"
 #include "../../asm/arch/arm/v35arm64/disassembler/arm64dis.h"
 #else
-#include "encodings.h"
+#include "encodings_dec.h"
 #include "operations.h"
 #include "arm64dis.h"
 #endif

--- a/libr/asm/arch/arm/v35arm64/deps.mk
+++ b/libr/asm/arch/arm/v35arm64/deps.mk
@@ -3,7 +3,7 @@ ARM64V35_HOME?=arch-arm64/
 ARM64V35_SRCDIR=$(ARM64V35_HOME)/disassembler/
 
 ARM64V35_CFLAGS=-I$(ARM64V35_SRCDIR)
-ARM64V35_OBJS=arm64dis.o pcode.o decode0.o decode1.o decode_fields32.o decode_scratchpad.o decode2.o operations.o encodings.o sysregs.o
+ARM64V35_OBJS=format.o pcode.o decode.o decode0.o decode1.o decode_fields32.o decode_scratchpad.o decode2.o operations.o encodings_dec.o regs.o
 ARM64V35_LINK=$(addprefix $(ARM64V35_SRCDIR),$(ARM64V35_OBJS))
 
 ${ARM64V35_LINK}: $(ARM64V35_SRCDIR)

--- a/libr/asm/p/asm_arm_v35.c
+++ b/libr/asm/p/asm_arm_v35.c
@@ -4,7 +4,7 @@
 #include <r_lib.h>
 
 #include "operations.h"
-#include "encodings.h"
+#include "encodings_dec.h"
 #include "arm64dis.h"
 
 static int disassemble(RAsm *a, RAsmOp *op, const ut8 *buf, int len) {


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**
Build Vector35 ARM64 plugin correctly and disassembly works.

**Test plan**
No test yet but planned. First, tests have to be brought back to the CI.
