### PR TITLE
Bring back tests in CI for plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
     name: Build radare2 extras and r2pipe
     runs-on: ubuntu-latest
     env:
-      TESTS: 'arm64v35 armthumb atombios baleful bcl ba2 blackfin blessr2 keystone-lib keystone rlang-duktape mc6809 microblaze msil pcap ppcdisasm psosvm swf unicorn-lib unicorn vc4 x86udis x86bea x86tab x86olly x86zyan z80-nc'
+      BUILDS: 'arm64v35 armthumb atombios baleful bcl ba2 blackfin blessr2 keystone-lib keystone rlang-duktape mc6809 microblaze msil pcap ppcdisasm psosvm swf unicorn-lib unicorn vc4 x86udis x86bea x86tab x86olly x86zyan z80-nc'
+      TESTS: 'microblaze olly-extras swf'
       R2PIPE_TESTS: 'r2pipe-go r2pipe-js r2pipe-py'
     steps:
     - uses: actions/checkout@v2
@@ -21,7 +22,7 @@ jobs:
         ref: master
         path: ./radare2
     - name: Install dependencies
-      run: sudo apt-get --assume-yes install wget unzip python3-wheel python3-setuptools build-essential python3-pip && sudo pip3 install meson ninja
+      run: sudo apt-get --assume-yes install libboost-dev python3-wheel python3-setuptools && sudo pip3 install meson ninja
     - name: Install radare2
       run: |
         export PATH=$PATH:/usr/local/bin
@@ -38,9 +39,20 @@ jobs:
         set -e
         export R2PM_GITDIR=`pwd`
         export R2PM_GITSKIP=1
-        for p in $TESTS ; do
+        for p in $BUILDS ; do
           echo $p
           r2pm -i $p
+        done
+        set +e
+    - name: Test plugins
+      working-directory: radare2/test
+      run: |
+        set -e
+        export R2PM_GITDIR=`pwd`
+        export R2PM_GITSKIP=1
+        for p in $TESTS ; do
+          echo $p
+          make $p
         done
         set +e
     - name: Compile and install r2pipe


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

#268 has removed tests of plugins and yara build in the CI. This commit bring back the tests but yara is not built yet in CI.

**Test plan**
Test are checked during CI.
