### PR TITLE
Translate arm64 analysis to v35 disassembler

### DIFF
--- a/libr/anal/p/anal_arm_v35.c
+++ b/libr/anal/p/anal_arm_v35.c
@@ -534,14 +534,14 @@ const char* arm_prefix_cond(RAnalOp *op, Condition cond_type) {
 		close_type = 1;
 		r_strbuf_appendf (&op->esil, "zf,!,?{,");
 		break;
-	/*case COND_HS:
+	case COND_CS:
 		close_type = 1;
 		r_strbuf_appendf (&op->esil, "cf,?{,");
 		break;
-	case COND_LO:
+	case COND_CC:
 		close_type = 1;
 		r_strbuf_appendf (&op->esil, "cf,!,?{,");
-		break;*/
+		break;
 	case COND_MI:
 		close_type = 1;
 		r_strbuf_appendf (&op->esil, "nf,?{,");
@@ -2314,6 +2314,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 	case ARM64_BR:
 		r_strbuf_setf (&op->esil, "%s,pc,=", REG64 (0));
 		break;
+	case ARM64_B_AL:
 	case ARM64_B:
 		/* capstone precompute resulting address, using PC + IMM */
 		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=", GETIMM64 (0));
@@ -2323,6 +2324,63 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 		break;
 	case ARM64_BLR:
 		r_strbuf_setf (&op->esil, "pc,lr,=,%s,pc,=", REG64 (0));
+		break;
+	case ARM64_B_CC:
+		arm_prefix_cond(op, COND_CC);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_CS:
+		arm_prefix_cond(op, COND_CS);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_EQ:
+		arm_prefix_cond(op, COND_EQ);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_GE:
+		arm_prefix_cond(op, COND_GE);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_GT:
+		arm_prefix_cond(op, COND_GT);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_HI:
+		arm_prefix_cond(op, COND_HI);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_LE:
+		arm_prefix_cond(op, COND_LE);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_LS:
+		arm_prefix_cond(op, COND_LS);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_LT:
+		arm_prefix_cond(op, COND_LT);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_MI:
+		arm_prefix_cond(op, COND_MI);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_NE:
+		arm_prefix_cond(op, COND_NE);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	// case ARM64_B_NV: return "b.nv"; uhh idk
+	case ARM64_B_PL:
+		arm_prefix_cond(op, COND_PL);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_VC:
+		arm_prefix_cond(op, COND_VC);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
+		break;
+	case ARM64_B_VS:
+		arm_prefix_cond(op, COND_VS);
+		r_strbuf_appendf (&op->esil, "%"PFMT64d",pc,=,}", GETIMM64 (0));
 		break;
 	case ARM64_CLZ:
 	{

--- a/libr/anal/p/anal_arm_v35.c
+++ b/libr/anal/p/anal_arm_v35.c
@@ -661,7 +661,6 @@ static ut64 shifted_imm64(Instruction *insn, int n, int sz) {
 #define VECARG64_APPEND(sb, n, i, s) arg64_append(sb, insn, n, i, s)
 #define COMMA(sb) r_strbuf_appendf (sb, ",")
 
-
 // #define VEC64(n) insn->detail->arm64.operands[n].vess
 #define VEC64_APPEND(sb, n, i) vector64_append(sb, insn, n, i)
 #define VEC64_MASK(sh, sz) (bitmask_by_width[63]^(bitmask_by_width[sz-1]<<sh))
@@ -1505,7 +1504,7 @@ break;
 
 static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len, Instruction *insn) {
 
-	const char *postfix = NULL;
+	const char *postfix = "";
 
 	r_strbuf_init (&op->esil);
 	r_strbuf_set (&op->esil, "");
@@ -1986,7 +1985,7 @@ static int analop_esil(RAnal *a, RAnalOp *op, ut64 addr, const ut8 *buf, int len
 				// I assume the DUPs here previously were to handle preindexing
 				// but it was never finished?
 				if (ISPREINDEX32()) {
-					r_strbuf_append (&op->esil, ",tmp,%s,=", REG64 (1));
+					r_strbuf_appendf (&op->esil, ",tmp,%s,=", REG64 (1));
 				}
 
 				r_strbuf_appendf (&op->esil, ",[%d],%s,=", size, REG64 (0));

--- a/libr/asm/arch/arm/v35arm64/Makefile
+++ b/libr/asm/arch/arm/v35arm64/Makefile
@@ -8,7 +8,7 @@ all: disassembler
 	$(MAKE) arm64dis.a
 
 disassembler: arch-arm64
-	-cd arch-arm64 && git pull
+	-cd arch-arm64 && git checkout master && git pull
 	cp -rf arch-arm64/disassembler disassembler
 
 arch-arm64:


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Add code for capstone arm64 plugin to vector35 plugin by converting fields where necessary and other minor changes. Mostly things map well from one to the other. 

**Test plan**

I will eventually try to get the whole arm64 test suite working, and also add tests for new instructions that weren't covered previously. 
