### PR TITLE
extras build for snowman to use QT5

### DIFF
--- a/r2snowman/Makefile
+++ b/r2snowman/Makefile
@@ -4,7 +4,7 @@ DESTDIR?=
 
 all: snowman
 	cd snowman ; git reset --hard
-	cd snowman/src ; cmake . ; make -j4
+	cd snowman/src ; cmake . -D NC_QT5=YES ; make -j4
 	cp -f snowman/src/nocode/nocode nocode
 
 install:


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ X ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Qt4 is out of date and several system repositories do not still include it. Snowman obviously hasn't been modified in a while, but have at least Qt5. Snowman builds just fine with Qt5 with a CMake flag.

https://github.com/fabianfreyer/snowman/blob/master/doc/build.asciidoc
