### PR TITLE
Correct check_buffer for bcl, atombios and pcap.

### DIFF
--- a/bcl/anal_bcl.c
+++ b/bcl/anal_bcl.c
@@ -76,7 +76,7 @@ static int bcl_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *buf, int len, 
 	return op->size;
 }
 
-static int set_reg_profile(RAnal *anal) {
+static bool set_reg_profile(RAnal *anal) {
 	const char *p = \
 		"=PC	pc\n"
 		"=SP	sp\n"
@@ -93,7 +93,7 @@ static int set_reg_profile(RAnal *anal) {
 	return r_reg_set_profile_string (anal->reg, p);
 }
 
-struct r_anal_plugin_t r_anal_plugin_bcl = {
+RAnalPlugin r_anal_plugin_bcl = {
 	.name = "bcl",
 	.desc = "Base Call DNA Illumina records",
 	.license = "BSD",
@@ -101,7 +101,7 @@ struct r_anal_plugin_t r_anal_plugin_bcl = {
 	.bits = 8,
 	.esil = true,
 	.op = &bcl_op,
-	.set_reg_profile = set_reg_profile,
+	.set_reg_profile = &set_reg_profile
 };
 
 #ifndef CORELIB

--- a/bcl/bin_bcl.c
+++ b/bcl/bin_bcl.c
@@ -5,7 +5,7 @@
 #include <r_lib.h>
 #include <r_bin.h>
 
-static bool __check_buffer(RBuffer *b) {
+static bool __check_buffer(RBinFile *bf, RBuffer *b) {
 	ut8 buf[8];
 	int length = r_buf_size (b);
 	int r = r_buf_read_at (b, 0, buf, sizeof (buf));
@@ -20,7 +20,7 @@ static bool __check_buffer(RBuffer *b) {
 }
 
 static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *buf, ut64 loadaddr, Sdb *sdb) {
-	return __check_buffer (buf);
+	return __check_buffer (bf, buf);
 }
 
 static ut64 baddr(RBinFile *bf) {

--- a/libr/anal/p/anal_atombios.c
+++ b/libr/anal/p/anal_atombios.c
@@ -399,7 +399,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 			op->cond = R_ANAL_COND_AL;
 			op->jump = sect->paddr;
 			op->eob = true;
-			esilprintf (op, "0x%08x,pc,4,sp,-=,sp,=[],pc,=", op->jump);
+			esilprintf (op, "0x%" PFMT64d ",pc,4,sp,-=,sp,=[],pc,=", op->jump);
 		} break;
 
 	// jmp imm16
@@ -413,7 +413,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 			op->cond = R_ANAL_COND_AL;
 			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->eob = true;
-			esilprintf (op, "0x%08x,pc,=", op->jump);
+			esilprintf (op, "0x%" PFMT64d ",pc,=", op->jump);
 		} break;
 	case 0x44:
 		{
@@ -426,7 +426,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
-			esilprintf (op, "$z,?{,0x%08x,pc,=,}", op->jump);
+			esilprintf (op, "$z,?{,0x%" PFMT64d ",pc,=,}", op->jump);
 		} break;
 	case 0x45:
 		{
@@ -439,7 +439,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
-			esilprintf (op, "$of,$sf,!=,?{,0x%08x,pc,=,}", op->jump);
+			esilprintf (op, "$of,$sf,!=,?{,0x%" PFMT64d ",pc,=,}", op->jump);
 		} break;
 	case 0x46:
 		{
@@ -452,7 +452,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
-			esilprintf (op, "$z,!,$of,$sf,==,&,?{,0x%08x,pc,=,}", op->jump);
+			esilprintf (op, "$z,!,$of,$sf,==,&,?{,0x%" PFMT64d ",pc,=,}", op->jump);
 		} break;
 	case 0x47:
 		{
@@ -465,7 +465,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
-			esilprintf (op, "$z,$of,$sf,!=,|,?{,0x%08x,pc,=,}", op->jump);
+			esilprintf (op, "$z,$of,$sf,!=,|,?{,0x%" PFMT64d ",pc,=,}", op->jump);
 		} break;
 	case 0x48:
 		{
@@ -478,7 +478,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
-			esilprintf (op, "$of,$sf,==,?{,0x%08x,pc,=,}", op->jump);
+			esilprintf (op, "$of,$sf,==,?{,0x%" PFMT64d ",pc,=,}", op->jump);
 		} break;
 	case 0x49:
 		{
@@ -491,7 +491,7 @@ static int atombios_op(RAnal *anal, RAnalOp *op, ut64 addr, const ut8 *b, int le
 			op->jump = cursect->paddr + r_read_at_le16(b, 1);
 			op->fail = addr + op->size;
 			op->eob = true;
-			esilprintf (op, "$z,!,?{,0x%08x,pc,=,}", op->jump);
+			esilprintf (op, "$z,!,?{,0x%" PFMT64d ",pc,=,}", op->jump);
 		} break;
 
 	// SET DATA BLOCK imm8 dataptr = &data[datatable[imm8]]

--- a/libr/bin/p/bin_atombios.c
+++ b/libr/bin/p/bin_atombios.c
@@ -16,8 +16,8 @@ static ut32 cmdtablesize[N_TABLES_CMD];
 static ut32 datatableoffs[N_TABLES_DATA];
 static ut32 datatablesize[N_TABLES_DATA];
 
-static bool check_buffer(RBuffer *b) {
-	if (!b || r_buf_size (b) < 0x70)
+static bool check_buffer(RBinFile *bf, RBuffer *b) {
+	if (r_buf_size (b) < 0x70)
 		return false;
 
 	ut8 magic[4] = {0};
@@ -30,7 +30,7 @@ static bool check_buffer(RBuffer *b) {
 }
 
 static bool load_buffer(RBinFile *bf, void **bin_obj, RBuffer *b, ut64 loadaddr, Sdb *sdb){
-	if (!check_buffer(b))
+	if (!check_buffer(bf, b))
 		return false;
 
 	ut8 i;

--- a/libr/bin/p/bin_pcap.c
+++ b/libr/bin/p/bin_pcap.c
@@ -20,7 +20,7 @@ static RBinInfo *info(RBinFile *bf) {
 	return ret;
 }
 
-static bool check_buffer(RBuffer *b) {
+static bool check_buffer(RBinFile *bf, RBuffer *b) {
 	r_return_val_if_fail (b, false);
 
 	switch (r_buf_read_be32_at (b, 0)) {


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #314 
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

`check_buffer` now takes two arguments as input.
