### PR TITLE
Correct EVM opcode max representation length

### DIFF
--- a/libr/asm/arch/evm/evm.h
+++ b/libr/asm/arch/evm/evm.h
@@ -158,7 +158,8 @@ typedef struct EvmOp {
 	EvmOpcodes op;
 	int len;
 	const char *txt;
-	char txt_buf[32];
+	// Largest opcode is "push32 0x" followed by hex value of 32 bytes.
+	char txt_buf[9+64+1];
 } EvmOp;
 
 typedef struct {


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #311 
- [ ] Mark this if you consider it ready to merge
- [x] I've added tests (optional)
- [ ] I wrote some documentation

**Description**
Increase length of opcode representation for large opcode like push32.
