### PR TITLE
added -fPIC to hexagon makefile. Kindof a kludge, but it works

### DIFF
--- a/libr/arch/hexagon/Makefile
+++ b/libr/arch/hexagon/Makefile
@@ -1,7 +1,7 @@
 SO=$(shell r2 -H R2_LIBEXT)
 PD=$(shell r2 -H R2_USER_PLUGINS)
 
-CFLAGS+=$(shell pkg-config --cflags r_util r_arch)
+CFLAGS+=$(shell pkg-config --cflags r_util r_arch) -fPIC
 LDFLAGS+=$(shell pkg-config --libs r_util r_arch)
 CFLAGS+=-g
 


### PR DESCRIPTION
Without it, older GCC would complain about relocations and shared objects.