### PR TITLE
Fix blackfin plugin compilation

### DIFF
--- a/libr/asm/p/arch_blackfin.c
+++ b/libr/asm/p/arch_blackfin.c
@@ -224,13 +224,18 @@ static RList *preludes(RArchSession *as) {
 }
 
 RArchPlugin r_arch_plugin_blackfin = {
-	.name = "blackfin",
+	.meta = {
+		.name = "blackfin",
+		.desc = "BlackFIN architecture plugin",
+		.author = "",
+		.version = "",
+		.license = "GPL",
+		.status = R_PLUGIN_STATUS_OK,
+	},
 	.arch = "blackfin",
-	.license = "GPL",
 	.bits = R_SYS_BITS_PACK1 (32),
 	.endian = R_SYS_ENDIAN_LITTLE,
 	.info = &info,
-	.desc = "BlackFIN architecture plugin",
 	.regs = getregs,
 	.preludes = preludes,
 	.encode = &encode,


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Fix compilation errors of the blackfin plugin due to `RArchPlugin` structure modifications (radareorg/radare2@97a7b7b4a3e7a1a8fc77b0cb62f6c2f9838b889b).
I have tested the installation with r2pm but I haven't checked that the plugin is working. 
