### PR TITLE
x86iced: add metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/x86iced"
+    schedule:
+      interval: "weekly"

--- a/x86iced/Cargo.toml
+++ b/x86iced/Cargo.toml
@@ -3,6 +3,9 @@ name = "x86iced"
 version = "0.1.0"
 edition = "2021"
 authors = ["Richard Patel <me@terorie.dev>"]
+publish = false
+license = "MIT"
+description = "radare2 plugin bundling the iced-x86 disassembler"
 
 [lib]
 crate-type = ["cdylib"]

--- a/x86iced/src/lib.rs
+++ b/x86iced/src/lib.rs
@@ -1,7 +1,9 @@
 #[allow(dead_code)]
 mod r2api_ext;
 
-use iced_x86::{Decoder, DecoderOptions, Formatter, GasFormatter, Instruction, IntelFormatter, MasmFormatter};
+use iced_x86::{
+    Decoder, DecoderOptions, Formatter, GasFormatter, Instruction, IntelFormatter, MasmFormatter,
+};
 use std::ffi::{c_char, c_int, c_void, CStr};
 use std::ptr::{null, null_mut};
 
@@ -19,7 +21,7 @@ unsafe fn r2c_strdup(s: &str) -> *mut c_char {
     let out_ptr = libc::malloc(s.len() + 1) as *mut c_char;
     assert!(!out_ptr.is_null(), "malloc failed");
     let out = std::slice::from_raw_parts_mut(out_ptr, s.len() + 1);
-    out.copy_from_slice(std::mem::transmute::<&[u8], &[c_char]>(s.as_bytes()));
+    out[..s.len()].copy_from_slice(std::mem::transmute::<&[u8], &[c_char]>(s.as_bytes()));
     out[s.len()] = 0;
     out_ptr
 }


### PR DESCRIPTION
- Enable Dependabot so we get automatic PRs for iced-x86 updates
- Add Cargo metadata (disable publish, MIT license, description)

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
