### PR TITLE
Fix to make afen installable

### DIFF
--- a/Makefile.acr
+++ b/Makefile.acr
@@ -27,6 +27,8 @@ help:
 
 #	@echo "  install-yara{2,3}  - install Yara 2 or 3 from Git"
 
+afen:
+	$(MAKE) -C afen
 baleful:
 	$(MAKE) -C baleful
 debug unicorn:
@@ -54,6 +56,8 @@ yara:
 	$(MAKE) -C yara/$@
 yara-clean:
 	$(MAKE) -C yara/yara clean
+afen-install:
+	$(MAKE) -C afen install DESTDIR=$(DESTDIR)
 baleful-install:
 	$(MAKE) -C baleful install DESTDIR=$(DESTDIR)
 debug-install unicorn-install:


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->

I forgot to check if it installs as well as to add the building and installing command to the `Makefile.acr`. Right now I tested it and the plugin can be installed, sorry for my laziness 😅 
