### PR TITLE
Repoint cmsis-svd repo to upstream cmsis-svd org

### DIFF
--- a/r2svd/Makefile
+++ b/r2svd/Makefile
@@ -3,7 +3,7 @@ BINDIR=$(shell r2pm -H R2PM_BINDIR)
 all: cmsis-svd
 
 cmsis-svd:
-	git clone --depth=1 https://github.com/brainstorm/cmsis-svd && cd cmsis-svd && git checkout regex_fix
+	git clone --depth=1 https://github.com/cmsis-svd/cmsis-svd && cd cmsis-svd
 	pip3 install -t $(shell pwd)/cmsis-svd/python lxml six
 
 clean:


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

The upstream cmsis-svd repo has updated to version 1.0 since https://github.com/cmsis-svd/cmsis-svd/pull/185
